### PR TITLE
feat: Implement Vulkan rendering layer foundation

### DIFF
--- a/novade-system/Cargo.toml
+++ b/novade-system/Cargo.toml
@@ -50,6 +50,8 @@ prometheus = { version = "0.13", features = ["process"] } #ANCHOR [NovaDE Develo
 warp = "0.3" # Restored from 0.1.23
 anyhow = "1.0" # Added for client example error handling
 futures-util = "0.3" # Added for client example StreamExt
+memoffset = "0.9" # Added for vertex attribute offsets
+glam = "0.24" # Added for matrix math in UBOs
 
 
 [features]

--- a/novade-system/src/renderers/vulkan/device.rs
+++ b/novade-system/src/renderers/vulkan/device.rs
@@ -4,19 +4,81 @@ use ash::vk;
 use std::collections::HashSet;
 use std::ffi::CStr;
 
+/// Represents a set of Vulkan features that the application might require.
+///
+/// This struct is populated based on checks during physical device suitability assessment.
+/// It helps in enabling only necessary and supported features when creating the logical device.
+#[derive(Default, Clone, Debug)]
+pub struct RequiredFeatures {
+    /// Indicates if sampler anisotropy is supported and should be enabled. (Spec 3.4)
+    pub sampler_anisotropy: bool,
+    /// Indicates if 64-bit integers in shaders are supported and should be enabled. (Spec 3.2)
+    pub shader_int64: bool,
+    // Add other features as needed by the application and specified in `Rendering Vulkan.md`
+    // For example: robust_buffer_access, geometry_shader, tessellation_shader, etc.
+}
+
+/// Holds the indices of queue families required by the application.
+///
+/// Each field is an `Option<u32>` because a single queue family might support multiple
+/// operation types (e.g., graphics, compute, and transfer).
+/// This structure is populated by `find_queue_families`.
+#[derive(Debug, Clone)]
 pub struct QueueFamilyIndices {
+    /// Index of the queue family that supports graphics operations.
     pub graphics_family: Option<u32>,
+    /// Index of the queue family that supports presentation to a surface.
     pub present_family: Option<u32>,
-    // TODO: Add compute_family, transfer_family if needed
+    /// Index of the queue family that supports compute operations.
+    pub compute_family: Option<u32>,
+    /// Index of the queue family that supports transfer operations.
+    pub transfer_family: Option<u32>,
 }
 
 impl QueueFamilyIndices {
-    pub fn is_complete(&self) -> bool {
+    /// Checks if essential queue families for graphics and presentation have been found.
+    pub fn is_complete_for_graphics_present(&self) -> bool {
         self.graphics_family.is_some() && self.present_family.is_some()
     }
+    // Add other completeness checks if necessary, e.g., for compute-only contexts.
 }
 
-pub fn pick_physical_device(instance: &ash::Instance, surface_loader: &ash::extensions::khr::Surface, surface: vk::SurfaceKHR) -> Result<vk::PhysicalDevice, String> {
+/// Contains information about the chosen physical device.
+///
+/// This includes the `vk::PhysicalDevice` handle, its properties, the queue family indices identified,
+/// and a summary of supported features relevant to the application.
+#[derive(Clone)]
+pub struct ChosenPhysicalDevice {
+    /// The Vulkan physical device handle.
+    pub physical_device: vk::PhysicalDevice,
+    /// Features confirmed to be supported by this `physical_device` that are relevant to the application.
+    pub supported_features: RequiredFeatures,
+    /// Properties of the `physical_device` (e.g., name, type, limits, API version).
+    pub properties: vk::PhysicalDeviceProperties,
+    /// Queue family indices found on this `physical_device`.
+    pub queue_family_indices: QueueFamilyIndices,
+}
+
+/// Selects the most suitable physical device (GPU) that meets the application's requirements.
+///
+/// This function enumerates available Vulkan-capable physical devices and evaluates them
+/// based on criteria defined in `Rendering Vulkan.md` (Spec 3.2), such as API version,
+/// device type (prioritizing integrated GPU for Vega 8), supported features,
+/// required extensions, and queue family capabilities.
+///
+/// # Arguments
+/// * `instance`: A reference to the `ash::Instance`.
+/// * `surface_loader`: A reference to the `ash::extensions::khr::Surface` loader.
+/// * `surface`: A `vk::SurfaceKHR` handle to check for presentation support.
+///
+/// # Returns
+/// A `Result` containing a `ChosenPhysicalDevice` struct with details about the selected device,
+/// or an error string if no suitable device is found.
+pub fn pick_physical_device(
+    instance: &ash::Instance,
+    surface_loader: &ash::extensions::khr::Surface,
+    surface: vk::SurfaceKHR,
+) -> Result<ChosenPhysicalDevice, String> {
     let physical_devices = unsafe {
         instance
             .enumerate_physical_devices()
@@ -27,117 +89,247 @@ pub fn pick_physical_device(instance: &ash::Instance, surface_loader: &ash::exte
         return Err("No GPUs with Vulkan support found!".to_string());
     }
 
-    let mut best_device: Option<vk::PhysicalDevice> = None;
-    let mut best_score = -1;
+    let mut best_candidate: Option<ChosenPhysicalDevice> = None;
+    let mut best_score = -1i32;
 
     for &p_device in physical_devices.iter() {
-        let score = rate_device_suitability(instance, p_device, surface_loader, surface);
+        let properties = unsafe { instance.get_physical_device_properties(p_device) };
+        let all_features = unsafe { instance.get_physical_device_features(p_device) };
+
+        // Check for Vulkan 1.3 API version support (Spec 3.2)
+        if properties.api_version < vk::API_VERSION_1_3 {
+            // Using eprintln for important diagnostic messages
+            eprintln!("Device {} does not support Vulkan 1.3 (API version: {}.{}.{}). Skipping.",
+                unsafe {CStr::from_ptr(properties.device_name.as_ptr()).to_string_lossy()},
+                vk::api_version_major(properties.api_version),
+                vk::api_version_minor(properties.api_version),
+                vk::api_version_patch(properties.api_version)
+            );
+            continue;
+        }
+
+        // Determine which of the application's required features are supported by this device
+        let current_supported_features = RequiredFeatures {
+            sampler_anisotropy: all_features.sampler_anisotropy == vk::TRUE,
+            shader_int64: all_features.shader_int64 == vk::TRUE,
+            // Populate other features based on `all_features`
+        };
+
+        // Basic suitability checks (e.g., queue families, extensions)
+        let queue_indices = find_queue_families(instance, p_device, surface_loader, surface, &properties);
+
+        // For graphics applications, graphics and present queues are essential.
+        if !queue_indices.is_complete_for_graphics_present() {
+             eprintln!("Device {} does not have complete graphics/present queue families. Skipping.", unsafe {CStr::from_ptr(properties.device_name.as_ptr()).to_string_lossy()});
+            continue;
+        }
+
+        let required_extensions = get_required_device_extensions();
+        if !check_device_extension_support(instance, p_device, &required_extensions) {
+            eprintln!("Device {} does not support required extensions. Skipping.", unsafe {CStr::from_ptr(properties.device_name.as_ptr()).to_string_lossy()});
+            continue;
+        }
+
+        // Score the device
+        let score = rate_device_suitability(&properties, &current_supported_features, &queue_indices);
+
         if score > best_score {
             best_score = score;
-            best_device = Some(p_device);
+            best_candidate = Some(ChosenPhysicalDevice {
+                physical_device: p_device,
+                supported_features: current_supported_features,
+                properties,
+                queue_family_indices: queue_indices,
+            });
         }
     }
 
-    if best_score < 0 { // Changed from if best_score == -1 to allow 0 as a valid score
-        return Err("Failed to find a suitable GPU!".to_string());
+    if best_score < 0 || best_candidate.is_none() { // best_score can be 0 for a minimally suitable device
+        return Err("Failed to find a suitable GPU that meets all criteria!".to_string());
     }
-    Ok(best_device.unwrap())
+    Ok(best_candidate.unwrap())
 }
 
-fn rate_device_suitability(instance: &ash::Instance, device: vk::PhysicalDevice, surface_loader: &ash::extensions::khr::Surface, surface: vk::SurfaceKHR) -> i32 {
-    let properties = unsafe { instance.get_physical_device_properties(device) };
-    let _features = unsafe { instance.get_physical_device_features(device) }; // Check specific features if needed
-
-    // Basic checks: must support graphics and presentation for this phase
-    let indices = find_queue_families(instance, device, surface_loader, surface);
-    if !indices.is_complete() {
-        return -1;
-    }
-
-    // Check for required extensions
-    let required_extensions = get_required_device_extensions();
-    if !check_device_extension_support(instance, device, &required_extensions) {
-        return -1;
-    }
-
-    // TODO: Check swapchain adequacy (formats, present modes) - will be done in swapchain.rs
-
+/// Rates the suitability of a physical device based on its properties, features, and queue families.
+///
+/// This is a helper for `pick_physical_device`.
+/// Adheres to `Rendering Vulkan.md` (Spec 3.2) for scoring criteria:
+/// - Prioritizes integrated GPUs (for target AMD Vega 8).
+/// - Scores based on essential supported features (e.g., sampler anisotropy).
+/// - Potentially penalizes or disqualifies if critical features are missing.
+/// - Adds score for meeting the target API version (Vulkan 1.3).
+fn rate_device_suitability(
+    properties: &vk::PhysicalDeviceProperties,
+    supported_features: &RequiredFeatures,
+    _indices: &QueueFamilyIndices, // May be used for scoring later if specific queue configs are preferred
+) -> i32 {
     let mut score = 0;
+
+    // Prioritize Integrated GPU as per Spec 3.2 for AMD Vega 8
     if properties.device_type == vk::PhysicalDeviceType::INTEGRATED_GPU {
-        score += 1000; // Prioritize iGPU as per docs/Rendering Vulkan.md for AMD Vega 8
+        score += 1000;
     } else if properties.device_type == vk::PhysicalDeviceType::DISCRETE_GPU {
-        score += 500;
+        score += 500; // Discrete GPUs are generally powerful
     }
-    // Add more scoring based on limits, features, Vulkan version etc.
-    // e.g. score += properties.limits.max_image_dimension2d;
+
+    // Score based on essential features (Spec 3.4)
+    // Sampler anisotropy is mentioned as a feature to check in Spec 3.2 and enable in Spec 3.4
+    if supported_features.sampler_anisotropy {
+        score += 100;
+    } else {
+        // If sampler anisotropy is strictly required by the application,
+        // this device might be unsuitable.
+        // For this example, we'll just not add score, but one could return -1.
+        eprintln!("Warning: Device {} does not support samplerAnisotropy.", unsafe {CStr::from_ptr(properties.device_name.as_ptr()).to_string_lossy()});
+        // return -1; // Uncomment if this feature is absolutely mandatory
+    }
+
+    // ShaderInt64 is mentioned as a feature to check in Spec 3.2
+    if supported_features.shader_int64 {
+        score += 50;
+    }
+
+    // Add more scoring based on limits (Spec 3.2), e.g., maxImageDimension2D, maxMemoryAllocationCount.
+    // Example: score += properties.limits.max_image_dimension2d / 1000;
+    // These would require defining what are "good" values for the application.
+
+    // API version check is primarily handled in pick_physical_device.
+    // Here, we confirm it's at least the targeted 1.3.
     if properties.api_version >= vk::API_VERSION_1_3 {
         score += 200;
-    } else if properties.api_version >= vk::API_VERSION_1_2 {
-        score += 100;
+    } else {
+        // This case should ideally not be reached if pick_physical_device filters correctly.
+        return -1; // Device must support at least Vulkan 1.3
     }
-
 
     score
 }
 
-pub fn find_queue_families(instance: &ash::Instance, device: vk::PhysicalDevice, surface_loader: &ash::extensions::khr::Surface, surface: vk::SurfaceKHR) -> QueueFamilyIndices {
+/// Identifies queue families for graphics, presentation, compute, and transfer operations.
+///
+/// Iterates through the physical device's queue families and selects indices for each required
+/// capability. It attempts to find dedicated queues where possible (especially for transfer)
+/// and falls back to using shared queues (e.g., graphics queue for compute/transfer) if necessary.
+/// Adheres to `Rendering Vulkan.md` (Spec 3.3).
+///
+/// # Arguments
+/// * `instance`: Reference to the `ash::Instance`.
+/// * `device`: The `vk::PhysicalDevice` to query.
+/// * `surface_loader`: Reference to the `ash::extensions::khr::Surface` loader.
+/// * `surface`: The `vk::SurfaceKHR` for checking presentation support.
+/// * `_properties`: Physical device properties (currently unused but passed for future use).
+///
+/// # Returns
+/// A `QueueFamilyIndices` struct populated with the found indices.
+pub fn find_queue_families(
+    instance: &ash::Instance,
+    device: vk::PhysicalDevice,
+    surface_loader: &ash::extensions::khr::Surface,
+    surface: vk::SurfaceKHR,
+    _properties: &vk::PhysicalDeviceProperties, // Could be used for smarter selection
+) -> QueueFamilyIndices {
     let queue_family_properties = unsafe { instance.get_physical_device_queue_family_properties(device) };
     let mut indices = QueueFamilyIndices {
         graphics_family: None,
         present_family: None,
+        compute_family: None,
+        transfer_family: None,
     };
 
+    // Try to find a dedicated transfer queue first (Spec 3.3 suggests it might be useful)
+    // A dedicated transfer queue is one that supports TRANSFER but not GRAPHICS or COMPUTE.
     for (i, queue_family) in queue_family_properties.iter().enumerate() {
-        if queue_family.queue_flags.contains(vk::QueueFlags::GRAPHICS) {
-            indices.graphics_family = Some(i as u32);
-        }
-
-        // Check for presentation support if a surface is provided
-        // This check might be deferred if surface is not available during initial device picking
-        if surface != vk::SurfaceKHR::null() {
-            let present_support = unsafe {
-                surface_loader
-                    .get_physical_device_surface_support(device, i as u32, surface)
-                    .unwrap_or(false)
-            };
-            if present_support {
-                indices.present_family = Some(i as u32);
-            }
-        }
-
-
-        if indices.is_complete() { // This might not be complete if surface is null
+        if queue_family.queue_flags.contains(vk::QueueFlags::TRANSFER) &&
+           !queue_family.queue_flags.contains(vk::QueueFlags::GRAPHICS) &&
+           !queue_family.queue_flags.contains(vk::QueueFlags::COMPUTE) {
+            indices.transfer_family = Some(i as u32);
             break;
         }
     }
-    // If present_family is still None because surface was null, it can be set to graphics_family
-    // as a placeholder, but this needs careful handling later when a real surface is available.
-    if surface == vk::SurfaceKHR::null() && indices.graphics_family.is_some() && indices.present_family.is_none() {
-        // This is a temporary measure for headless/initialization scenarios.
-        // Real presentation capability must be verified with a surface.
-        // For now, we assume if it has graphics, it might present. This is often true for primary GPUs.
-        // indices.present_family = indices.graphics_family;
-        // The subtask description in vulkan/mod.rs suggests setting present_family = graphics_family as a temporary fix.
+
+    for (i, queue_family) in queue_family_properties.iter().enumerate() {
+        let i_u32 = i as u32;
+
+        if queue_family.queue_flags.contains(vk::QueueFlags::GRAPHICS) {
+            if indices.graphics_family.is_none() { // Take the first one found
+                indices.graphics_family = Some(i_u32);
+            }
+        }
+
+        if queue_family.queue_flags.contains(vk::QueueFlags::COMPUTE) {
+            if indices.compute_family.is_none() {
+                 // Prefer a compute queue that is not the graphics queue if possible
+                if indices.graphics_family != Some(i_u32) {
+                    indices.compute_family = Some(i_u32);
+                }
+            }
+        }
+
+        // If a dedicated transfer queue wasn't found, use one that supports transfer,
+        // preferring one that is not graphics or compute if possible.
+        if indices.transfer_family.is_none() && queue_family.queue_flags.contains(vk::QueueFlags::TRANSFER) {
+             if indices.graphics_family != Some(i_u32) && indices.compute_family != Some(i_u32) { // Prefer non-graphics/compute for transfer
+                indices.transfer_family = Some(i_u32);
+            }
+        }
+
+        // Check for presentation support for the current queue family index `i`
+        if surface != vk::SurfaceKHR::null() { // Only check if a surface is provided
+            let present_support = unsafe {
+                surface_loader
+                    .get_physical_device_surface_support(device, i_u32, surface)
+                    .unwrap_or(false) // Assume no support on error
+            };
+            if present_support && indices.present_family.is_none() { // Take the first one found
+                indices.present_family = Some(i_u32);
+            }
+        }
+    }
+
+    // Fallbacks if dedicated queues are not found (Spec 3.3 suggests preferring combined queues if possible)
+    if indices.compute_family.is_none() {
+        indices.compute_family = indices.graphics_family; // Often compute can run on graphics queue
+    }
+    if indices.transfer_family.is_none() { // If still no transfer queue (dedicated or semi-dedicated)
+        indices.transfer_family = indices.graphics_family; // Transfer can also run on graphics/compute queue
+    }
+
+    // Final check for present_family: if it's still None but we have a surface and a graphics_family,
+    // check if the graphics_family can present. This is a common scenario.
+    if surface != vk::SurfaceKHR::null() && indices.present_family.is_none() && indices.graphics_family.is_some() {
+        let present_support_on_graphics = unsafe {
+            surface_loader.get_physical_device_surface_support(device, indices.graphics_family.unwrap(), surface)
+                .unwrap_or(false)
+        };
+        if present_support_on_graphics {
+            indices.present_family = indices.graphics_family;
+        }
     }
 
     indices
 }
 
+/// Gets a list of required device extensions based on `Rendering Vulkan.md` (Spec 3.2 & 3.4).
 fn get_required_device_extensions() -> Vec<&'static CStr> {
+    // As per Spec 3.2 & 3.4
     vec![
-        Swapchain::name(),
-        ash::extensions::khr::ExternalMemoryFd::name(),
-        ash::extensions::ext::ExternalMemoryDmaBuf::name(),
-        ash::extensions::khr::ExternalMemory::name(), // Dependency for the above
-        ash::extensions::khr::GetPhysicalDeviceProperties2::name(), // Often used with external memory
-        // VK_EXT_image_drm_format_modifier is more complex, handled separately if needed.
+        Swapchain::name(), // VK_KHR_swapchain
+        ash::extensions::ext::ExternalMemoryDmaBuf::name(), // VK_EXT_external_memory_dmabuf
+        ash::extensions::khr::ExternalMemoryFd::name(),     // VK_KHR_external_memory_fd
+        // ash::extensions::khr::ExternalMemory::name(), // This is implicitly supported by Vulkan 1.1+ if the others are.
+        // ash::extensions::khr::GetPhysicalDeviceProperties2::name(), // Implicitly supported with Vulkan 1.1+
+        // VK_EXT_image_drm_format_modifier is optional per spec (section 3.2), can be added if strictly needed by DMA-BUF import logic.
     ]
 }
 
+/// Checks if a physical device supports all required device-level extensions.
 fn check_device_extension_support(instance: &ash::Instance, device: vk::PhysicalDevice, required_extensions: &[&'static CStr]) -> bool {
     let available_extensions = match unsafe { instance.enumerate_device_extension_properties(device) } {
         Ok(props) => props,
-        Err(_) => return false,
+        Err(e) => {
+            eprintln!("Failed to enumerate device extensions for {:?}: {}", unsafe { CStr::from_ptr(instance.get_physical_device_properties(device).device_name.as_ptr()) }, e);
+            return false;
+        }
     };
 
     let mut available_extension_names = HashSet::new();
@@ -148,86 +340,134 @@ fn check_device_extension_support(instance: &ash::Instance, device: vk::Physical
 
     for required_ext_name in required_extensions {
         if !available_extension_names.contains(required_ext_name) {
-            println!("Required device extension not found: {:?}", required_ext_name);
+            eprintln!("Required device extension not found on device {:?}: {:?}", unsafe { CStr::from_ptr(instance.get_physical_device_properties(device).device_name.as_ptr()) }, required_ext_name);
             return false;
         }
     }
     true
 }
 
+/// Holds the handles to various device queues.
+///
+/// Queues for compute and transfer are optional as they might share the graphics queue.
+pub struct LogicalDeviceQueues {
+    /// Queue for graphics commands.
+    pub graphics_queue: vk::Queue,
+    /// Queue for presentation commands.
+    pub present_queue: vk::Queue,
+    /// Optional queue for compute commands.
+    pub compute_queue: Option<vk::Queue>,
+    /// Optional queue for transfer commands.
+    pub transfer_queue: Option<vk::Queue>,
+}
+
+/// Creates a logical device (VkDevice) from a chosen physical device.
+///
+/// This function configures and creates the logical device interface to the GPU.
+/// It enables specified device features (like sampler anisotropy) if supported,
+/// required device extensions (like swapchain, external memory for DMA-BUF),
+/// and Vulkan 1.3 features (dynamic rendering, synchronization2).
+/// It also retrieves handles to the graphics, present, and optionally compute/transfer queues.
+/// Adheres to `Rendering Vulkan.md` (Spec 3.4).
+///
+/// # Arguments
+/// * `instance`: Reference to the `ash::Instance`.
+/// * `chosen_device`: A reference to `ChosenPhysicalDevice` containing the selected physical device
+///   and its relevant properties, features, and queue indices.
+///
+/// # Returns
+/// A `Result` containing a tuple of the created `ash::Device` and `LogicalDeviceQueues`,
+/// or an error string on failure.
 pub fn create_logical_device(
     instance: &ash::Instance,
-    physical_device: vk::PhysicalDevice,
-    indices: &QueueFamilyIndices,
-) -> Result<(ash::Device, vk::Queue, vk::Queue), String> {
+    chosen_device: &ChosenPhysicalDevice,
+) -> Result<(ash::Device, LogicalDeviceQueues), String> {
+    let indices = &chosen_device.queue_family_indices;
     let mut unique_queue_families = HashSet::new();
-    unique_queue_families.insert(indices.graphics_family.ok_or_else(|| "Graphics family index is None".to_string())?);
-    if let Some(present_idx) = indices.present_family { // Only add if present_family is Some
-        unique_queue_families.insert(present_idx);
-    } else {
-        // This case should ideally be handled before calling create_logical_device
-        // if presentation is strictly required at this stage.
-        // For now, proceeding with graphics only if present is None, which means present_queue will be same as graphics_queue.
-        // Or, we can error out if present_family is None but required.
-        // The updated VulkanRenderer::new logic in the prompt assumes present_family will be Some (even if it's same as graphics).
-        return Err("Present family index is None, cannot create distinct present queue.".to_string());
+
+    let graphics_q_idx = indices.graphics_family.ok_or_else(|| "Graphics family index is None".to_string())?;
+    unique_queue_families.insert(graphics_q_idx);
+
+    // Presentation queue is essential for graphical applications using a surface.
+    let present_q_idx = indices.present_family.ok_or_else(|| "Present family index is None but required for logical device creation with a surface".to_string())?;
+    unique_queue_families.insert(present_q_idx);
+
+    // Add compute and transfer queue indices if they are distinct and available
+    if let Some(compute_idx) = indices.compute_family {
+        unique_queue_families.insert(compute_idx);
+    }
+    if let Some(transfer_idx) = indices.transfer_family {
+        unique_queue_families.insert(transfer_idx);
     }
 
+    let queue_priorities = [1.0f32]; // Default priority
+    let queue_create_infos: Vec<vk::DeviceQueueCreateInfo> = unique_queue_families
+        .iter()
+        .map(|&queue_family_index| {
+            vk::DeviceQueueCreateInfo::builder()
+                .queue_family_index(queue_family_index)
+                .queue_priorities(&queue_priorities)
+                .build()
+        })
+        .collect();
 
-    let queue_priorities = [1.0f32];
-    let mut queue_create_infos = Vec::new();
-
-    for queue_family_index in unique_queue_families {
-        let queue_create_info = vk::DeviceQueueCreateInfo::builder()
-            .queue_family_index(queue_family_index)
-            .queue_priorities(&queue_priorities)
-            .build();
-        queue_create_infos.push(queue_create_info);
+    // Enable features that were confirmed supported and are required by the application (Spec 3.4)
+    let mut features_to_enable_builder = vk::PhysicalDeviceFeatures::builder();
+    if chosen_device.supported_features.sampler_anisotropy {
+        features_to_enable_builder = features_to_enable_builder.sampler_anisotropy(true);
     }
+    if chosen_device.supported_features.shader_int64 {
+        features_to_enable_builder = features_to_enable_builder.shader_int64(true);
+    }
+    // Enable other features from chosen_device.supported_features as needed.
+    let features_to_enable = features_to_enable_builder.build();
 
-    let mut physical_device_features = vk::PhysicalDeviceFeatures::builder();
-    // Enable specific features if needed, e.g. physical_device_features.sampler_anisotropy(true);
-    // Check availability first via instance.get_physical_device_features(physical_device)
 
     let required_extensions_raw: Vec<*const i8> = get_required_device_extensions()
         .iter()
         .map(|s| s.as_ptr())
         .collect();
 
-    let mut features13 = vk::PhysicalDeviceVulkan13Features::builder()
-        .dynamic_rendering(true)
-        .synchronization2(true);
+    // Vulkan 1.3 features (dynamic_rendering, synchronization2) (Spec 3.4)
+    // These should be supported if apiVersion >= 1.3 (which is checked in pick_physical_device)
+    let mut features13_builder = vk::PhysicalDeviceVulkan13Features::builder();
 
-    // Check actual support for these 1.3 features
+    // Query for actual Vulkan 1.3 feature support for robustness, though device.properties.api_version >= 1.3 implies support.
     let mut supported_features13_query = vk::PhysicalDeviceVulkan13Features::default();
     let mut features2_query = vk::PhysicalDeviceFeatures2::builder().push_next(&mut supported_features13_query);
-    unsafe { instance.get_physical_device_features2(physical_device, &mut features2_query) };
+    unsafe { instance.get_physical_device_features2(chosen_device.physical_device, &mut features2_query) };
 
-    if !supported_features13_query.dynamic_rendering { features13.dynamic_rendering = false; }
-    if !supported_features13_query.synchronization2 { features13.synchronization2 = false; }
+    if supported_features13_query.dynamic_rendering == vk::TRUE {
+        features13_builder = features13_builder.dynamic_rendering(true);
+    }
+    if supported_features13_query.synchronization2 == vk::TRUE {
+         features13_builder = features13_builder.synchronization2(true);
+    }
+    let mut features13 = features13_builder.build(); // Build here to pass a mutable reference later if needed
 
 
     let mut device_create_info = vk::DeviceCreateInfo::builder()
         .queue_create_infos(&queue_create_infos)
-        .enabled_features(&physical_device_features)
+        .enabled_features(&features_to_enable)
         .enabled_extension_names(&required_extensions_raw);
 
-    // Only push_next if at least one 1.3 feature is enabled and supported
+    // Only add VkPhysicalDeviceVulkan13Features to pNext if any of its members are true.
     if features13.dynamic_rendering == vk::TRUE || features13.synchronization2 == vk::TRUE {
         device_create_info = device_create_info.push_next(&mut features13);
     }
 
-
     let device: ash::Device = unsafe {
         instance
-            .create_device(physical_device, &device_create_info, None)
+            .create_device(chosen_device.physical_device, &device_create_info, None)
             .map_err(|e| format!("Failed to create logical device: {}", e))?
     };
 
-    let graphics_queue = unsafe { device.get_device_queue(indices.graphics_family.unwrap(), 0) };
-    // Ensure present_family has a value before unwrapping
-    let present_queue_family = indices.present_family.ok_or_else(|| "Present family index is None after device creation".to_string())?;
-    let present_queue = unsafe { device.get_device_queue(present_queue_family, 0) };
+    // Retrieve queue handles
+    let graphics_queue = unsafe { device.get_device_queue(graphics_q_idx, 0) };
+    let present_queue = unsafe { device.get_device_queue(present_q_idx, 0) }; // present_q_idx is guaranteed Some by earlier check
 
-    Ok((device, graphics_queue, present_queue))
+    let compute_queue = indices.compute_family.map(|idx| unsafe { device.get_device_queue(idx, 0) });
+    let transfer_queue = indices.transfer_family.map(|idx| unsafe { device.get_device_queue(idx, 0) });
+
+    Ok((device, LogicalDeviceQueues { graphics_queue, present_queue, compute_queue, transfer_queue } ))
 }

--- a/novade-system/src/renderers/vulkan/framebuffer.rs
+++ b/novade-system/src/renderers/vulkan/framebuffer.rs
@@ -7,34 +7,95 @@ pub struct VulkanFramebuffer {
     framebuffer: vk::Framebuffer,
 }
 
+/// Creates a Vulkan Framebuffer.
+///
+/// A framebuffer defines the collection of attachments that will be used by a render pass instance.
+/// For the simple case in WP-302, this typically means attaching a single swapchain image view
+/// as the color target.
+///
+/// This function aligns with `Rendering Vulkan.md` (Spec 6.5 - Framebuffer-Erstellung).
+///
+/// # Arguments
+/// * `device`: A reference to the logical `ash::Device`.
+/// * `render_pass`: The `vk::RenderPass` with which this framebuffer must be compatible.
+///   The attachments specified here must match those expected by the `render_pass`.
+/// * `image_view`: The `vk::ImageView` to be attached. For swapchain rendering, this will be
+///   an image view of a swapchain image.
+/// * `extent`: The `vk::Extent2D` (width and height) of the framebuffer. This should match
+///   the extent of the attached image views and the render area of the render pass.
+///
+/// # Returns
+/// A `Result` containing the created `vk::Framebuffer` handle, or an error string
+/// if creation fails.
+///
+/// # `Rendering Vulkan.md` Specification Mapping (Spec 6.5):
+/// - `renderPass`: Matches the `render_pass` parameter.
+/// - `attachmentCount`, `pAttachments`: Configured with a single `image_view`.
+/// - `width`, `height`: Matches the `extent` parameter.
+/// - `layers`: Set to 1, appropriate for standard 2D rendering.
+pub fn create_vulkan_framebuffer(
+    device: &AshDevice,
+    render_pass: vk::RenderPass,
+/// A framebuffer references all `vk::ImageView` attachments that are used by a render pass instance.
+/// For this simple case (WP-302), it will typically reference a single swapchain image view
+/// as the color attachment.
+/// Aligns with `Rendering Vulkan.md` (Spec 6.5).
+///
+/// # Arguments
+/// * `device`: A reference to the logical `ash::Device`.
+/// * `render_pass`: The `vk::RenderPass` with which this framebuffer will be compatible.
+/// * `image_view`: The `vk::ImageView` to be used as the color attachment.
+/// * `extent`: The `vk::Extent2D` (width and height) of the framebuffer.
+///
+/// # Returns
+/// A `Result` containing the created `vk::Framebuffer` or an error string on failure.
+pub fn create_vulkan_framebuffer(
+    device: &AshDevice,
+    render_pass: vk::RenderPass,
+    image_view: vk::ImageView,
+    extent: vk::Extent2D,
+) -> Result<vk::Framebuffer, String> {
+    let attachments = [image_view];
+    let framebuffer_create_info = vk::FramebufferCreateInfo::builder()
+        .render_pass(render_pass)
+        .attachments(&attachments)
+        .width(extent.width)
+        .height(extent.height)
+        .layers(1); // For non-stereoscopic 2D, layers is 1
+
+    unsafe {
+        device
+            .create_framebuffer(&framebuffer_create_info, None)
+            .map_err(|e| format!("Failed to create framebuffer: {}", e))
+    }
+}
+
 // ANCHOR: VulkanFramebuffer Implementation
 impl VulkanFramebuffer {
+    /// Creates a new `VulkanFramebuffer` instance.
+    ///
+    /// This constructor wraps the `create_vulkan_framebuffer` free function.
+    ///
+    /// # Arguments
+    /// * `device`: An `Arc` reference to the logical `ash::Device`.
+    /// * `render_pass`: The `vk::RenderPass` for compatibility.
+    /// * `image_view`: The `vk::ImageView` for the color attachment.
+    /// * `extent`: The `vk::Extent2D` dimensions.
+    ///
+    /// # Returns
+    /// A `Result` containing the new `VulkanFramebuffer` or an error string.
     pub fn new(
         device: Arc<AshDevice>,
         render_pass: vk::RenderPass, // The render pass this framebuffer is compatible with
         image_view: vk::ImageView,   // The image view to attach
         extent: vk::Extent2D,        // Dimensions of the framebuffer
     ) -> Result<Self, String> {
+        let framebuffer_handle =
+            create_vulkan_framebuffer(device.as_ref(), render_pass, image_view, extent)?;
 
-        // ANCHOR_EXT: Framebuffer Create Info
-        let attachments = [image_view];
-        let framebuffer_create_info = vk::FramebufferCreateInfo::builder()
-            .render_pass(render_pass)
-            .attachments(&attachments)
-            .width(extent.width)
-            .height(extent.height)
-            .layers(1)
-            .build();
-
-        let framebuffer = unsafe {
-            device
-                .create_framebuffer(&framebuffer_create_info, None)
-                .map_err(|e| format!("Failed to create framebuffer: {}", e))?
-        };
-
-        // It might be useful to log creation, perhaps with extent or image_view handle
-        // println!("VulkanFramebuffer created for ImageView {:?} with extent {}x{}", image_view, extent.width, extent.height);
-        Ok(Self { device, framebuffer })
+        // Optional: log creation
+        // println!("VulkanFramebuffer created (handle: {:?}) for ImageView {:?} with extent {}x{}", framebuffer_handle, image_view, extent.width, extent.height);
+        Ok(Self { device, framebuffer: framebuffer_handle })
     }
 
     // ANCHOR: Accessor for vk::Framebuffer

--- a/novade-system/src/renderers/vulkan/image.rs
+++ b/novade-system/src/renderers/vulkan/image.rs
@@ -4,26 +4,61 @@ use gpu_allocator::MemoryUsage as GpuMemoryUsage;
 use std::sync::{Arc, Mutex};
 
 // ANCHOR: VulkanImage Struct Definition
+/// Represents a Vulkan image (`vk::Image`) and its associated memory allocation
+/// managed by `gpu-allocator`.
+///
+/// This struct encapsulates the `vk::Image` handle, its `gpu_allocator::vulkan::Allocation`,
+/// and essential properties like extent and format. It handles the creation of the image
+/// and its memory, and ensures proper destruction and deallocation when dropped.
+///
+/// It aligns with `Rendering Vulkan.md` (Spec 9.1 for image creation principles).
+/// The `gpu-allocator` crate is used for memory management, which is a Rust alternative
+/// to the VMA C++ library mentioned in the specification.
 pub struct VulkanImage {
+    /// Arc-wrapped logical device handle, shared for image operations.
     device: Arc<AshDevice>,
+    /// Arc-wrapped mutex-guarded allocator, shared for memory management.
     allocator: Arc<Mutex<vma::Allocator>>,
-    pub image: vk::Image, // Public for direct use in render pass attachments, descriptor updates, etc.
-    allocation: Option<vma::Allocation>, // Option to allow taking it in drop
-    pub extent: vk::Extent3D, // Public for info
-    pub format: vk::Format,   // Public for info (e.g., creating image views)
-    // current_layout: vk::ImageLayout, // Could be added if image tracks its own layout
+    /// The underlying Vulkan image handle. Public for direct use where needed (e.g., render pass attachments).
+    pub image: vk::Image,
+    /// The memory allocation for this image, managed by `gpu-allocator`.
+    /// Stored as an `Option` to allow it to be taken during `Drop`.
+    allocation: Option<vma::Allocation>,
+    /// The dimensions (width, height, depth) of the image. Public for informational purposes.
+    pub extent: vk::Extent3D,
+    /// The Vulkan format of the image data. Public for informational purposes (e.g., when creating image views).
+    pub format: vk::Format,
+    // current_layout: vk::ImageLayout, // Could be added if image tracks its own layout state.
 }
 
 // ANCHOR: VulkanImage Implementation
 impl VulkanImage {
+    /// Creates a new `VulkanImage` with allocated device memory.
+    ///
+    /// This constructor takes all necessary information to create a `vk::Image`
+    /// and allocate its memory using `gpu-allocator`.
+    ///
+    /// # Arguments
+    /// * `device`: An `Arc` reference to the logical `ash::Device`.
+    /// * `allocator`: An `Arc<Mutex<...>>` reference to the `gpu_allocator::vulkan::Allocator`.
+    /// * `image_create_info`: A reference to `vk::ImageCreateInfo` defining the image properties.
+    ///   Important fields like `extent`, `mip_levels`, `array_layers`, `format`, `tiling`, `usage`,
+    ///   and `initial_layout` must be correctly set by the caller as per Spec 9.1.
+    /// * `memory_usage`: `gpu_allocator::MemoryUsage` (e.g., `GpuOnly`, `CpuToGpu`) indicating
+    ///   the desired memory properties for the allocation. For typical image resources like textures
+    ///   or attachments, `GpuMemoryUsage::GpuOnly` is common.
+    ///
+    /// # Returns
+    /// A `Result` containing the new `VulkanImage` or an error string on failure.
     pub fn new(
         device: Arc<AshDevice>,
         allocator: Arc<Mutex<vma::Allocator>>,
         image_create_info: &vk::ImageCreateInfo, // Pass by reference as it can be large
         memory_usage: GpuMemoryUsage,        // e.g., GpuOnly, CpuToGpu
     ) -> Result<Self, String> {
+        // Basic validation based on Vulkan specification requirements for ImageCreateInfo
         if image_create_info.extent.width == 0 || image_create_info.extent.height == 0 || image_create_info.extent.depth == 0 {
-            return Err("Image extent dimensions cannot be zero.".to_string());
+            return Err("Image extent dimensions (width, height, depth) cannot be zero.".to_string());
         }
         if image_create_info.mip_levels == 0 {
             return Err("Image mip_levels cannot be zero.".to_string());
@@ -32,45 +67,81 @@ impl VulkanImage {
             return Err("Image array_layers cannot be zero.".to_string());
         }
 
+        // Prepare allocation info for gpu-allocator
         let allocation_create_info = vma::AllocationCreateInfo {
             usage: memory_usage,
-            // flags, required_flags, preferred_flags, pool can be specified if needed
-            ..Default::default()
+            // flags, required_flags, preferred_flags, pool can be specified for more control
+            ..Default::default() // Sensible defaults for other fields
         };
 
+        // Create the image and allocate memory using gpu-allocator
+        // The allocator's create_image method handles both vkCreateImage and memory allocation/binding.
         let (image, allocation) = unsafe {
             allocator
                 .lock()
                 .map_err(|_| "Failed to lock allocator mutex for image creation".to_string())?
                 .create_image(image_create_info, &allocation_create_info)
-                .map_err(|e| format!("VMA failed to create image: {:?}", e))?
+                .map_err(|e| format!("gpu-allocator failed to create image (format: {:?}, extent: {:?}): {:?}",
+                                     image_create_info.format, image_create_info.extent, e))?
         };
 
         Ok(Self {
             device,
             allocator,
             image,
-            allocation: Some(allocation),
+            allocation: Some(allocation), // Store the allocation to be freed on Drop
             extent: image_create_info.extent,
             format: image_create_info.format,
-            // current_layout: image_create_info.initial_layout, // Store initial layout
+            // current_layout: image_create_info.initial_layout, // Optionally store initial layout
         })
     }
 
     // ANCHOR_EXT: create_image_view (Associated function or method)
     // Making this an associated function for now, but could be a method on VulkanImage.
+    // ANCHOR_EXT: create_image_view (Associated function or method)
+    /// Creates a `vk::ImageView` for a given `vk::Image`.
+    ///
+    /// An image view describes how to access the image and which parts of the image to access.
+    /// It's required for using images in descriptor sets or as framebuffer attachments.
+    /// This function aligns with `Rendering Vulkan.md` (Spec 9.2).
+    ///
+    /// # Arguments
+    /// * `device`: A reference to the logical `ash::Device`.
+    /// * `image`: The `vk::Image` for which to create the view.
+    /// * `view_type`: The `vk::ImageViewType` (e.g., `TYPE_2D`, `TYPE_CUBE`, `TYPE_2D_ARRAY`).
+    /// * `format`: The `vk::Format` of the image view (must be compatible with the image's format).
+    /// * `aspect_flags`: `vk::ImageAspectFlags` specifying which aspects of the image are included in the view
+    ///   (e.g., `COLOR`, `DEPTH`, `STENCIL`).
+    /// * `base_mip_level`: The first mipmap level accessible to the view.
+    /// * `level_count`: The number of mipmap levels (starting from `base_mip_level`) accessible to the view.
+    /// * `base_array_layer`: The first array layer accessible to the view.
+    /// * `layer_count`: The number of array layers (starting from `base_array_layer`) accessible to the view.
+    ///
+    /// # Returns
+    /// A `Result` containing the created `vk::ImageView` or an error string on failure.
     pub fn create_image_view(
-        device: &AshDevice, // Can take &Arc<AshDevice> too
+        device: &AshDevice,
         image: vk::Image,
+        view_type: vk::ImageViewType,
         format: vk::Format,
         aspect_flags: vk::ImageAspectFlags,
-        mip_levels: u32, // Pass mip_levels for the view
+        base_mip_level: u32,
+        level_count: u32,
+        base_array_layer: u32,
+        layer_count: u32,
     ) -> Result<vk::ImageView, String> {
+        if level_count == 0 {
+            return Err("level_count for an image view cannot be zero.".to_string());
+        }
+        if layer_count == 0 {
+            return Err("layer_count for an image view cannot be zero.".to_string());
+        }
+
         let image_view_create_info = vk::ImageViewCreateInfo::builder()
             .image(image)
-            .view_type(vk::ImageViewType::TYPE_2D) // Assuming 2D, make flexible if needed
+            .view_type(view_type)
             .format(format)
-            .components(vk::ComponentMapping {
+            .components(vk::ComponentMapping { // Default: No component swizzling
                 r: vk::ComponentSwizzle::IDENTITY,
                 g: vk::ComponentSwizzle::IDENTITY,
                 b: vk::ComponentSwizzle::IDENTITY,
@@ -78,15 +149,16 @@ impl VulkanImage {
             })
             .subresource_range(vk::ImageSubresourceRange {
                 aspect_mask: aspect_flags,
-                base_mip_level: 0,
-                level_count: mip_levels,
-                base_array_layer: 0,
-                layer_count: 1, // Assuming 1 layer, make flexible if needed (e.g. for cube maps)
+                base_mip_level,
+                level_count,
+                base_array_layer,
+                layer_count,
             });
 
         unsafe {
             device.create_image_view(&image_view_create_info, None)
-        }.map_err(|e| format!("Failed to create image view: {}", e))
+        }.map_err(|e| format!("Failed to create image view (format: {:?}, aspect: {:?} view_type: {:?} levels: {}-{}, layers: {}-{}): {}",
+            format, aspect_flags, view_type, base_mip_level, base_mip_level + level_count -1, base_array_layer, base_array_layer + layer_count -1, e))
     }
 
     // ANCHOR: Accessors

--- a/novade-system/src/renderers/vulkan/instance.rs
+++ b/novade-system/src/renderers/vulkan/instance.rs
@@ -3,22 +3,18 @@ use ash::extensions::{ext::DebugUtils, khr::Surface};
 use ash::vk;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
-use std::ptr;
-use raw_window_handle::{WaylandDisplayHandle, HasRawDisplayHandle}; // For Wayland display handle
+// use std::ptr; // ptr is not directly used, CString::as_ptr is used.
+// use raw_window_handle::{WaylandDisplayHandle, HasRawDisplayHandle}; // Not directly used in this file after previous changes
 
 // Temporary struct to satisfy HasRawDisplayHandle for testing instance extensions.
 // In a real scenario, this would come from Smithay's Wayland integration.
-struct DummyWaylandDisplay;
-unsafe impl HasRawDisplayHandle for DummyWaylandDisplay {
-    fn raw_display_handle(&self) -> raw_window_handle::RawDisplayHandle {
-        let mut wh = WaylandDisplayHandle::empty();
-        // wh.display = /* some non-null pointer, e.g., Box::into_raw(Box::new(0)) for testing purposes only */;
-        // This is tricky without a real Wayland display. For instance creation itself,
-        // it's not strictly needed unless getting surface extensions.
-        // Let's assume for now Wayland extensions are requested but not strictly validated here.
-        raw_window_handle::RawDisplayHandle::Wayland(wh)
-    }
-}
+// struct DummyWaylandDisplay; // Not strictly needed for instance creation logic itself
+// unsafe impl HasRawDisplayHandle for DummyWaylandDisplay {
+//     fn raw_display_handle(&self) -> raw_window_handle::RawDisplayHandle {
+//         let mut wh = WaylandDisplayHandle::empty();
+//         raw_window_handle::RawDisplayHandle::Wayland(wh)
+//     }
+// }
 
 
 const VALIDATION_LAYERS: [&'static str; 1] = ["VK_LAYER_KHRONOS_validation"];
@@ -28,6 +24,19 @@ const ENABLE_VALIDATION_LAYERS: bool = true;
 #[cfg(not(debug_assertions))]
 const ENABLE_VALIDATION_LAYERS: bool = false;
 
+/// unsafe extern "system" fn vulkan_debug_callback
+///
+/// This is the callback function invoked by the Vulkan validation layers when a debug message is generated.
+/// It prints the message to stderr, prefixed with severity and type.
+///
+/// # Arguments
+/// * `message_severity`: The severity of the message (e.g., ERROR, WARNING, INFO, VERBOSE).
+/// * `message_type`: The type of the message (e.g., GENERAL, VALIDATION, PERFORMANCE).
+/// * `p_callback_data`: Pointer to a `VkDebugUtilsMessengerCallbackDataEXT` struct containing details about the message.
+/// * `_p_user_data`: User data pointer, not used in this implementation.
+///
+/// # Returns
+/// `vk::Bool32` (effectively `vk::FALSE`) indicating that the Vulkan call triggering the message should not be aborted.
 unsafe extern "system" fn vulkan_debug_callback(
     message_severity: vk::DebugUtilsMessageSeverityFlagsEXT,
     message_type: vk::DebugUtilsMessageTypeFlagsEXT,
@@ -47,8 +56,9 @@ unsafe extern "system" fn vulkan_debug_callback(
         CStr::from_ptr(callback_data.p_message).to_string_lossy()
     };
 
-    println!(
-        "[{:?} {:?}] ({}: {}) {}",
+    // TODO: Integrate with a proper logger, e.g., tracing crate
+    eprintln!( // Changed to eprintln for debug messages
+        "VULKAN DEBUG: [{:?} {:?}] ({}: {}) {}",
         message_severity,
         message_type,
         message_id_name,
@@ -58,36 +68,108 @@ unsafe extern "system" fn vulkan_debug_callback(
     vk::FALSE
 }
 
-
+/// Creates and loads a Vulkan entry point.
+///
+/// The entry point is required to initialize the Vulkan library and load global function pointers.
+/// It's the very first step in using the Vulkan API.
 pub fn create_entry() -> Result<ash::Entry, String> {
     unsafe {
         ash::Entry::load().map_err(|e| format!("Failed to load Vulkan entry: {}", e))
     }
 }
 
+/// Checks if all required instance extensions are supported by the Vulkan implementation.
+///
+/// # Arguments
+/// * `entry`: A reference to the loaded `ash::Entry` point.
+/// * `required_extensions_cstrs`: A slice of `CStr` references representing the names of required extensions.
+///
+/// # Returns
+/// `Ok(())` if all required extensions are supported, otherwise an `Err` with a message.
+fn check_required_extensions_support(entry: &ash::Entry, required_extensions_cstrs: &[&CStr]) -> Result<(), String> {
+    let available_extensions = entry
+        .enumerate_instance_extension_properties(None)
+        .map_err(|e| format!("Failed to enumerate instance extensions: {}", e))?;
+
+    for required_ext_name_cstr in required_extensions_cstrs {
+        let found = available_extensions.iter().any(|props| {
+            let avail_ext_name = unsafe { CStr::from_ptr(props.extension_name.as_ptr()) };
+            avail_ext_name == *required_ext_name_cstr
+        });
+
+        if !found {
+            return Err(format!(
+                "Required instance extension not supported: {:?}",
+                required_ext_name_cstr
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Creates a Vulkan instance.
+///
+/// This function initializes the core Vulkan API, sets up application information,
+/// enables necessary instance-level extensions (like surface and Wayland integration),
+/// and configures validation layers with a debug messenger if enabled in debug builds.
+/// It adheres to the specifications outlined in `Rendering Vulkan.md`, particularly section 3.1.
+///
+/// # Arguments
+///
+/// * `entry` - A reference to the loaded `ash::Entry` point.
+///
+/// # Returns
+///
+/// A `Result` containing a tuple with:
+/// 1. The created `ash::Instance`.
+/// 2. An `Option<ash::extensions::ext::DebugUtils>` loader (Some if validation enabled).
+/// 3. An `Option<vk::DebugUtilsMessengerEXT>` handle (Some if validation enabled).
+/// Returns an error string on failure (e.g., validation layers not supported, required extensions missing).
+///
+/// # `Rendering Vulkan.md` Specification Mapping:
+/// - **Spec 3.1 (Vulkan-Instanz-Erstellung):**
+///   - `VkApplicationInfo`: Configured with "SmithayCompositor" as application name,
+///     "SmithayVulkanBackend" as engine name. `apiVersion` is set to `VK_API_VERSION_1_3`.
+///     Application and engine versions are set to `0.1.0.0` (project specific) rather than `1.0.0.0` from spec
+///     to maintain consistency with potential overall project versioning.
+///   - `VkInstanceCreateInfo`: Enables `VK_KHR_surface`, `VK_KHR_wayland_surface` (platform-specific),
+///     and `VK_EXT_debug_utils` (if validation is active). Support for these extensions is verified.
+///   - Validation Layer: `VK_LAYER_KHRONOS_validation` is enabled in debug builds (`ENABLE_VALIDATION_LAYERS`).
+///     Its availability is checked via `check_validation_layer_support`.
+///   - Debug Callback (`vulkan_debug_callback`): Configured with message severities ERROR, WARNING, and VERBOSE,
+///     and message types GENERAL, VALIDATION, and PERFORMANCE, as per Spec II.A and 3.1.
 pub fn create_instance(entry: &ash::Entry) -> Result<(ash::Instance, Option<DebugUtils>, Option<vk::DebugUtilsMessengerEXT>), String> {
     if ENABLE_VALIDATION_LAYERS && !check_validation_layer_support(entry) {
         return Err("Validation layers requested, but not available!".to_string());
     }
 
-    let app_name = CString::new("NovaDE Compositor").unwrap();
-    let engine_name = CString::new("NovaDE Engine").unwrap();
+    // According to Spec 3.1
+    let app_name = CString::new("SmithayCompositor").unwrap();
+    let engine_name = CString::new("SmithayVulkanBackend").unwrap();
     let app_info = vk::ApplicationInfo::builder()
         .application_name(&app_name)
-        .application_version(vk::make_api_version(0, 1, 0, 0))
+        .application_version(vk::make_api_version(0, 1, 0, 0)) // Spec says 1,0,0 but project is 0.1.0
         .engine_name(&engine_name)
-        .engine_version(vk::make_api_version(0, 1, 0, 0))
-        .api_version(vk::API_VERSION_1_3); // Request Vulkan 1.3
+        .engine_version(vk::make_api_version(0, 1, 0, 0))   // Spec says 1,0,0
+        .api_version(vk::API_VERSION_1_3);
 
-    let mut required_extensions = vec![
-        Surface::name().as_ptr(),
-        ash::extensions::khr::WaylandSurface::name().as_ptr(), // For Wayland surface
-    ];
+    // Define CString names for extensions to check
+    let surface_ext_name = Surface::name();
+    let wayland_surface_ext_name = ash::extensions::khr::WaylandSurface::name();
+    let debug_utils_ext_name = DebugUtils::name();
+
+    let mut required_extensions_cstrs_to_check = vec![surface_ext_name, wayland_surface_ext_name];
     if ENABLE_VALIDATION_LAYERS {
-        required_extensions.push(DebugUtils::name().as_ptr());
+        required_extensions_cstrs_to_check.push(debug_utils_ext_name);
     }
+    check_required_extensions_support(entry, &required_extensions_cstrs_to_check)?;
 
-    // TODO: Check if these extensions are actually available using entry.enumerate_instance_extension_properties()
+
+    let required_extensions_ptrs: Vec<*const c_char> = required_extensions_cstrs_to_check
+        .iter()
+        .map(|c_str| c_str.as_ptr())
+        .collect();
+
 
     let layers_names_raw: Vec<*const c_char> = VALIDATION_LAYERS
         .iter()
@@ -96,18 +178,18 @@ pub fn create_instance(entry: &ash::Entry) -> Result<(ash::Instance, Option<Debu
 
     let mut create_info = vk::InstanceCreateInfo::builder()
         .application_info(&app_info)
-        .enabled_extension_names(&required_extensions);
+        .enabled_extension_names(&required_extensions_ptrs);
 
     if ENABLE_VALIDATION_LAYERS {
         create_info = create_info.enabled_layer_names(&layers_names_raw);
     }
 
+    // According to Spec "Instanz- und Debug-Messenger-Einrichtung", II.A and 3.1
     let mut debug_utils_messenger_create_info = vk::DebugUtilsMessengerCreateInfoEXT::builder()
         .message_severity(
             vk::DebugUtilsMessageSeverityFlagsEXT::ERROR
                 | vk::DebugUtilsMessageSeverityFlagsEXT::WARNING
-                // | vk::DebugUtilsMessageSeverityFlagsEXT::INFO
-                // | vk::DebugUtilsMessageSeverityFlagsEXT::VERBOSE,
+                | vk::DebugUtilsMessageSeverityFlagsEXT::VERBOSE, // Added VERBOSE
         )
         .message_type(
             vk::DebugUtilsMessageTypeFlagsEXT::GENERAL
@@ -141,22 +223,33 @@ pub fn create_instance(entry: &ash::Entry) -> Result<(ash::Instance, Option<Debu
     Ok((instance, debug_utils, debug_utils_messenger))
 }
 
+/// Checks if the required validation layers (specifically `VK_LAYER_KHRONOS_validation`) are supported.
+///
+/// # Arguments
+/// * `entry`: A reference to the loaded `ash::Entry` point.
+///
+/// # Returns
+/// `true` if all required validation layers are supported, `false` otherwise.
 fn check_validation_layer_support(entry: &ash::Entry) -> bool {
     let available_layers = match entry.enumerate_instance_layer_properties() {
         Ok(layers) => layers,
-        Err(_) => return false,
+        Err(e) => {
+            eprintln!("Failed to enumerate instance layer properties: {}", e);
+            return false;
+        }
     };
 
     for layer_name_str in VALIDATION_LAYERS.iter() {
+        // Safe to unwrap, VALIDATION_LAYERS are constant strings
         let layer_name_cstr = CString::new(*layer_name_str).unwrap();
-        let layer_name_raw = layer_name_cstr.as_ptr();
 
         let found = available_layers.iter().any(|layer_properties| {
             let available_layer_name = unsafe { CStr::from_ptr(layer_properties.layer_name.as_ptr()) };
-            available_layer_name.to_bytes_with_nul() == layer_name_cstr.as_bytes_with_nul()
+            available_layer_name == layer_name_cstr.as_ref() // Compare CStr directly
         });
 
         if !found {
+            eprintln!("Validation layer not found: {}", layer_name_str);
             return false;
         }
     }

--- a/novade-system/src/renderers/vulkan/memory.rs
+++ b/novade-system/src/renderers/vulkan/memory.rs
@@ -3,6 +3,31 @@ use ash::vk;
 use gpu_allocator::vulkan::{Allocator, AllocatorCreateDesc, Allocation, AllocationCreateDesc, AllocationScheme};
 use gpu_allocator::MemoryLocation; // MemoryLocation::GpuOnly, MemoryLocation::CpuToGpu, etc.
 
+/// Creates a Vulkan memory allocator using the `gpu-allocator` crate.
+///
+/// This function initializes an `Allocator` which is responsible for managing Vulkan device memory.
+/// It corresponds to the VMA initialization described in `Rendering Vulkan.md` (Spec 4.1),
+/// adapted for the `gpu-allocator` API.
+///
+/// # Arguments
+/// * `instance`: A reference to the `ash::Instance`.
+/// * `physical_device`: The `vk::PhysicalDevice` that the allocator will manage memory for.
+/// * `device`: A reference to the logical `ash::Device`.
+///
+/// # Returns
+/// A `Result` containing the initialized `gpu_allocator::vulkan::Allocator`,
+/// or an error string if initialization fails.
+///
+/// # `Rendering Vulkan.md` Specification Mapping (Spec 4.1 - VMA-Initialisierung):
+/// - `VmaAllocatorCreateInfo` fields are mapped to `gpu_allocator::vulkan::AllocatorCreateDesc`:
+///   - `physicalDevice`, `device`, `instance`: Directly provided.
+///   - `flags` (e.g., `VMA_ALLOCATOR_CREATE_KHR_BIND_MEMORY2_BIT`): Partly covered by `buffer_device_address`
+///     in `AllocatorCreateDesc`. Other advanced binding features are managed internally by `gpu-allocator`.
+///   - `preferredLargeHeapBlockSize`: Corresponds to `allocation_sizes` in `AllocatorCreateDesc`.
+///     Currently uses `Default::default()`. Spec recommendation for VMA (256MB or heap/8) is VMA-specific.
+///   - `pAllocationCallbacks`: Not directly exposed by `gpu-allocator`'s high-level `new` function.
+///   - `pVulkanFunctions`: Handled internally by `gpu-allocator` when built with the `ash` feature.
+/// - The function aims to create a ready-to-use `Allocator` handle.
 pub fn create_allocator(
     instance: &ash::Instance,
     physical_device: vk::PhysicalDevice,
@@ -12,13 +37,36 @@ pub fn create_allocator(
         instance: instance.clone(), // Allocator may need to clone these
         device: device.clone(),
         physical_device,
-        debug_settings: Default::default(), // Configure as needed
-        buffer_device_address: false, // Enable if bufferDeviceAddress feature is used
-        allocation_sizes: Default::default(), // Use default block sizes or customize
+        debug_settings: Default::default(), // Configure as needed (e.g., for logging, validation)
+        buffer_device_address: false, // Enable only if the bufferDeviceAddress Vulkan feature is used.
+        allocation_sizes: Default::default(), // Use default block sizes. Can be customized for performance tuning.
     })
     .map_err(|e| format!("Failed to create Vulkan memory allocator: {:?}", e))
 }
 
+/// Creates a Vulkan buffer and allocates memory for it using the provided allocator.
+///
+/// This function handles the creation of a `vk::Buffer`, querying its memory requirements,
+/// allocating the necessary `vk::DeviceMemory` using `gpu-allocator`, and binding
+/// the memory to the buffer.
+///
+/// It aligns with `Rendering Vulkan.md` (Spec 4.4 for Buffer-Erstellung and Spec 4.2/4.5
+/// for UMA-optimized memory selection via the `location` parameter).
+///
+/// # Arguments
+/// * `allocator`: A mutable reference to the `gpu_allocator::vulkan::Allocator`.
+/// * `device`: A reference to the logical `ash::Device` (used for `vkCreateBuffer`).
+/// * `size`: The desired size of the buffer in bytes (`vk::DeviceSize`).
+/// * `usage`: `vk::BufferUsageFlags` specifying how the buffer will be used (e.g., vertex, index, uniform).
+/// * `location`: `gpu_allocator::MemoryLocation` indicating the desired memory properties
+///   (e.g., `MemoryLocation::GpuOnly`, `MemoryLocation::CpuToGpu`). For UMA systems (like AMD Vega 8),
+///   `MemoryLocation::CpuToGpu` is often preferred for staging or frequently updated buffers as it typically
+///   maps to `HOST_VISIBLE | DEVICE_LOCAL` memory. `MemoryLocation::GpuOnly` is suitable for static
+///   data after initial upload.
+///
+/// # Returns
+/// A `Result` containing a tuple of the created `vk::Buffer` and the `gpu_allocator::vulkan::Allocation`,
+/// or an error string on failure.
 pub fn create_buffer(
     allocator: &mut Allocator,
     device: &ash::Device, // Needed for vkCreateBuffer
@@ -29,7 +77,7 @@ pub fn create_buffer(
     let buffer_info = vk::BufferCreateInfo::builder()
         .size(size)
         .usage(usage)
-        .sharing_mode(vk::SharingMode::EXCLUSIVE); // Assuming exclusive for simplicity
+        .sharing_mode(vk::SharingMode::EXCLUSIVE); // Assuming exclusive for simplicity, adjust if sharing needed
 
     let buffer = unsafe {
         device
@@ -39,16 +87,21 @@ pub fn create_buffer(
 
     let requirements = unsafe { device.get_buffer_memory_requirements(buffer) };
 
-    let allocation = allocator
-        .allocate(&AllocationCreateDesc {
-            name: "buffer", // For debugging
-            requirements,
-            location,
-            scheme: AllocationScheme::GpuAllocatorManaged, // Let gpu-allocator manage it
-            linear: true, // Buffers are typically linear
-        })
-        .map_err(|e| format!("Failed to allocate memory for buffer: {:?}", e))?;
+    // AllocationCreateDesc allows specifying the name for debugging purposes.
+    let allocation_desc = AllocationCreateDesc {
+        name: "buffer_allocation", // Descriptive name
+        requirements,
+        location,
+        scheme: AllocationScheme::GpuAllocatorManaged, // Let gpu-allocator manage the underlying VkDeviceMemory
+        linear: true, // Buffers are linear resources
+    };
 
+    let allocation = allocator
+        .allocate(&allocation_desc)
+        .map_err(|e| format!("Failed to allocate memory for buffer (size: {}, usage: {:?}, location: {:?}): {:?}", size, usage, location, e))?;
+
+    // Bind the allocated memory to the buffer.
+    // The `allocation.offset()` is important if the allocator sub-allocates from larger blocks.
     unsafe {
         device
             .bind_buffer_memory(buffer, allocation.memory(), allocation.offset())
@@ -57,6 +110,34 @@ pub fn create_buffer(
     Ok((buffer, allocation))
 }
 
+/// Creates a Vulkan image and allocates memory for it using the provided allocator.
+///
+/// This function handles the creation of a `vk::Image` using the provided `vk::ImageCreateInfo`,
+/// querying its memory requirements, allocating the necessary `vk::DeviceMemory` via `gpu-allocator`,
+/// and binding the memory to the image.
+///
+/// It aligns with `Rendering Vulkan.md` (Spec 9.1 for Image-Erstellung and Spec 4.4 for
+/// general resource creation principles). The creation of `vk::ImageView` is handled separately.
+///
+/// # Arguments
+/// * `allocator`: A mutable reference to the `gpu_allocator::vulkan::Allocator`.
+/// * `device`: A reference to the logical `ash::Device` (used for `vkCreateImage`).
+/// * `create_info`: A reference to `vk::ImageCreateInfo` specifying the properties of the image
+///   to be created (e.g., type, format, extent, usage, tiling).
+/// * `location`: `gpu_allocator::MemoryLocation` indicating the desired memory properties
+///   (e.g., `MemoryLocation::GpuOnly` for textures and render targets, `MemoryLocation::CpuToGpu`
+///   if CPU access is needed, though less common for optimal images).
+///
+/// # Returns
+/// A `Result` containing a tuple of the created `vk::Image` and the `gpu_allocator::vulkan::Allocation`,
+/// or an error string on failure.
+///
+/// # `Rendering Vulkan.md` Specification Mapping (Spec 9.1):
+/// - `VkImageCreateInfo` fields (`imageType`, `format`, `extent`, `mipLevels`, `arrayLayers`, `samples`,
+///   `tiling`, `usage`, `initialLayout`) are expected to be correctly set in the `create_info` argument
+///   by the caller, as per Spec 9.1.
+/// - Memory allocation uses `VMA_MEMORY_USAGE_GPU_ONLY` (mapped to `MemoryLocation::GpuOnly`) for typical
+///   images like textures or attachments.
 pub fn create_image(
     allocator: &mut Allocator,
     device: &ash::Device, // Needed for vkCreateImage
@@ -66,21 +147,24 @@ pub fn create_image(
     let image = unsafe {
         device
             .create_image(create_info, None)
-            .map_err(|e| format!("Failed to create image: {}", e))?
+            .map_err(|e| format!("Failed to create image with format {:?}, extent {:?}: {}", create_info.format, create_info.extent, e))?
     };
 
     let requirements = unsafe { device.get_image_memory_requirements(image) };
 
-    let allocation = allocator
-        .allocate(&AllocationCreateDesc {
-            name: "image",
-            requirements,
-            location,
-            scheme: AllocationScheme::GpuAllocatorManaged,
-            linear: false, // Images are typically tiled/optimal
-        })
-        .map_err(|e| format!("Failed to allocate memory for image: {:?}", e))?;
+    let allocation_desc = AllocationCreateDesc {
+        name: "image_allocation", // Descriptive name
+        requirements,
+        location,
+        scheme: AllocationScheme::GpuAllocatorManaged,
+        linear: create_info.tiling == vk::ImageTiling::LINEAR, // Images are linear if tiling is LINEAR, otherwise optimal/tiled (non-linear)
+    };
 
+    let allocation = allocator
+        .allocate(&allocation_desc)
+        .map_err(|e| format!("Failed to allocate memory for image (format {:?}, extent {:?}, location: {:?}): {:?}", create_info.format, create_info.extent, location, e))?;
+
+    // Bind the allocated memory to the image.
     unsafe {
         device
             .bind_image_memory(image, allocation.memory(), allocation.offset())

--- a/novade-system/src/renderers/vulkan/mod.rs
+++ b/novade-system/src/renderers/vulkan/mod.rs
@@ -7,38 +7,57 @@ pub mod surface;
 pub mod swapchain;
 pub mod memory;
 pub mod dmabuf;
-pub mod texture_pipeline; // New
-pub mod command_buffer;   // New
-pub mod render_pass;      // Added for render pass
-pub mod framebuffer;      // Added for framebuffer
-pub mod shader;           // Added for shader modules
-pub mod pipeline;         // Added for graphics pipelines
-pub mod sync;             // Added for synchronization primitives
-pub mod renderer;         // Added for NovaVulkanRenderer
-pub mod buffer;           // Added for VMA-backed VulkanBuffer
-pub mod image;            // Added for VMA-backed VulkanImage
+pub mod texture_pipeline;
+pub mod command_buffer;
+pub mod render_pass;
+pub mod framebuffer;
+pub mod shader;
+pub mod pipeline;
+pub mod sync;
+pub mod renderer;
+pub mod buffer;
+pub mod image;
 
-pub use self::context::VulkanContext; // Assuming context.rs defines VulkanContext
-pub use self::swapchain::VulkanSwapchain; // Added for the new VulkanSwapchain struct
-pub use self::render_pass::VulkanRenderPass; // Added for VulkanRenderPass
-pub use self::framebuffer::VulkanFramebuffer; // Added for VulkanFramebuffer
-pub use self::shader::VulkanShaderModule; // Added for VulkanShaderModule
-pub use self::pipeline::VulkanPipeline; // Added for VulkanPipeline
-pub use self::sync::FrameSyncPrimitives; // Added for FrameSyncPrimitives
-pub use self.renderer::NovaVulkanRenderer; // Added for NovaVulkanRenderer
-pub use self::buffer::VulkanBuffer; // Added for VMA-backed VulkanBuffer
-pub use self::image::VulkanImage;   // Added for VMA-backed VulkanImage
+pub use self::context::VulkanContext;
+pub use self::swapchain::VulkanSwapchain;
+pub use self::render_pass::VulkanRenderPass;
+pub use self::framebuffer::VulkanFramebuffer;
+pub use self::shader::VulkanShaderModule;
+pub use self::pipeline::VulkanPipeline;
+pub use self::sync::FrameSyncPrimitives;
+pub use self.renderer::NovaVulkanRenderer;
+pub use self::buffer::VulkanBuffer;
+pub use self::image::VulkanImage;
 
 use crate::renderer_interface::RendererInterface;
 use novade_core::types::geometry::Size2D;
 use ash::vk;
 use raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle};
 use gpu_allocator::vulkan::Allocator;
+use gpu_allocator::MemoryLocation;
 use texture_pipeline::{TextureId, GpuTexture};
 use std::collections::HashMap;
-use std::os::unix::io::RawFd; // For DMA-BUF FD
-use super::dmabuf::{self, DmaBufImportOptions}; // dmabuf module and options struct
+use std::sync::Arc;
+use std::os::unix::io::RawFd;
+use super::dmabuf::{self, DmaBufImportOptions};
 
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+struct UniformBufferObject {
+    model: [[f32; 4]; 4],
+    view: [[f32; 4]; 4],
+    proj: [[f32; 4]; 4],
+}
+
+impl Default for UniformBufferObject {
+    fn default() -> Self {
+        Self {
+            model: glam::Mat4::IDENTITY.to_cols_array_2d(),
+            view: glam::Mat4::IDENTITY.to_cols_array_2d(),
+            proj: glam::Mat4::IDENTITY.to_cols_array_2d(),
+        }
+    }
+}
 
 pub struct VulkanRenderer {
     entry: ash::Entry,
@@ -46,16 +65,18 @@ pub struct VulkanRenderer {
     debug_utils: Option<ash::extensions::ext::DebugUtils>,
     debug_messenger: Option<vk::DebugUtilsMessengerEXT>,
 
-    surface_loader: ash::extensions::khr::Surface, // New
-    surface: vk::SurfaceKHR,                       // New
+    surface_loader: ash::extensions::khr::Surface,
+    surface: vk::SurfaceKHR,
 
     physical_device: vk::PhysicalDevice,
     device: ash::Device,
     graphics_queue: vk::Queue,
     present_queue: vk::Queue,
+    compute_queue: Option<vk::Queue>,
+    physical_device_properties: vk::PhysicalDeviceProperties, // Storing for timestamp period
 
-    swapchain_loader: ash::extensions::khr::Swapchain, // New
-    swapchain: vk::SwapchainKHR,                       // New
+    swapchain_loader: ash::extensions::khr::Swapchain,
+    swapchain: vk::SwapchainKHR,
     swapchain_images: Vec<vk::Image>,
     swapchain_image_views: Vec<vk::ImageView>,
     swapchain_format: vk::Format,
@@ -63,12 +84,87 @@ pub struct VulkanRenderer {
 
     allocator: Allocator,
 
-    command_pool: vk::CommandPool, // New: For transfer operations primarily
-    textures: HashMap<TextureId, GpuTexture>, // New
+    render_command_pool: vk::CommandPool,
+    render_command_buffers: Vec<vk::CommandBuffer>,
+
+    image_available_semaphores: Vec<vk::Semaphore>,
+    render_finished_semaphores: Vec<vk::Semaphore>,
+    in_flight_fences: Vec<vk::Fence>,
+    current_frame_index: usize,
+
+    render_pass: vk::RenderPass,
+
+    descriptor_set_layout: vk::DescriptorSetLayout,
+    descriptor_pool: vk::DescriptorPool,
+
+    pipeline_layout: vk::PipelineLayout,
+    graphics_pipeline: vk::Pipeline,
+    swapchain_framebuffers: Vec<vk::Framebuffer>,
+
+    vertex_buffer: vk::Buffer,
+    vertex_buffer_memory: Option<gpu_allocator::vulkan::Allocation>,
+    index_buffer: vk::Buffer,
+    index_buffer_memory: Option<gpu_allocator::vulkan::Allocation>,
+    index_count: u32,
+
+    uniform_buffers: Vec<vk::Buffer>,
+    uniform_buffers_memory: Vec<Option<gpu_allocator::vulkan::Allocation>>,
+    descriptor_sets: Vec<vk::DescriptorSet>,
+
+    textures: HashMap<TextureId, GpuTexture>,
+    default_texture_id: Option<TextureId>,
+
+    compute_command_pool: Option<vk::CommandPool>,
+    compute_command_buffer: Option<vk::CommandBuffer>,
+    compute_descriptor_set_layout: Option<vk::DescriptorSetLayout>,
+    compute_pipeline_layout: Option<vk::PipelineLayout>,
+    compute_pipeline: Option<vk::Pipeline>,
+    compute_descriptor_set: Option<vk::DescriptorSet>,
+    compute_storage_image: Option<GpuTexture>,
+    compute_fence: Option<vk::Fence>,
+
+    // --- WP-06 Timestamp Queries ---
+    timestamp_query_pool: Option<vk::QueryPool>,
+    // We'll use 2 queries per frame in flight for simple duration: start and end.
+    // So, query_count = MAX_FRAMES_IN_FLIGHT * 2
+    // --- End WP-06 ---
 }
 
+const MAX_FRAMES_IN_FLIGHT: usize = 2;
+const TIMESTAMP_QUERY_COUNT: u32 = 2; // For start and end of frame rendering
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+struct SimpleVertex {
+    pos: [f32; 2],
+    #[allow(dead_code)]
+    color: [f32; 3],
+    tex_coord: [f32; 2],
+}
+
+impl SimpleVertex {
+    fn get_binding_description() -> vk::VertexInputBindingDescription {
+        vk::VertexInputBindingDescription::builder()
+            .binding(0)
+            .stride(std::mem::size_of::<Self>() as u32)
+            .input_rate(vk::VertexInputRate::VERTEX)
+            .build()
+    }
+
+    fn get_attribute_descriptions() -> [vk::VertexInputAttributeDescription; 2] {
+        [
+            vk::VertexInputAttributeDescription::builder()
+                .binding(0).location(0) .format(vk::Format::R32G32_SFLOAT)
+                .offset(memoffset::offset_of!(SimpleVertex, pos) as u32).build(),
+            vk::VertexInputAttributeDescription::builder()
+                .binding(0).location(1).format(vk::Format::R32G32_SFLOAT)
+                .offset(memoffset::offset_of!(SimpleVertex, tex_coord) as u32).build(),
+        ]
+    }
+}
+
+
 impl VulkanRenderer {
-    // Updated signature to accept window handles
     pub fn new(
         raw_display_handle_provider: &impl HasRawDisplayHandle,
         raw_window_handle_provider: &impl HasRawWindowHandle,
@@ -76,68 +172,529 @@ impl VulkanRenderer {
         window_height: u32
     ) -> Result<Self, String> {
         let entry = instance::create_entry()?;
-        let (instance, debug_utils, debug_messenger) = instance::create_instance(&entry)?;
+        let (instance_ash, debug_utils, debug_messenger) = instance::create_instance(&entry)?;
 
-        let surface_loader = ash::extensions::khr::Surface::new(&entry, &instance);
-        let surface = surface::create_surface(&entry, &instance, raw_display_handle_provider, raw_window_handle_provider)?;
+        let surface_loader = ash::extensions::khr::Surface::new(&entry, &instance_ash);
+        let surface = surface::create_surface(&entry, &instance_ash, raw_display_handle_provider, raw_window_handle_provider)?;
 
-        let physical_device = device::pick_physical_device(&instance, &surface_loader, surface)?;
-        let q_indices = device::find_queue_families(&instance, physical_device, &surface_loader, surface);
-        if !q_indices.is_complete() {
-            return Err("Failed to find all required queue families (graphics and present).".to_string());
-        }
+        let chosen_physical_device = device::pick_physical_device(&instance_ash, &surface_loader, surface)?;
+        let physical_device_properties = chosen_physical_device.properties.clone(); // Store for timestamp period
 
-        let (logical_device, graphics_queue, present_queue) =
-            device::create_logical_device(&instance, physical_device, &q_indices)?;
+        let (logical_device_ash, queues) = device::create_logical_device(&instance_ash, &chosen_physical_device)?;
+        let graphics_queue = queues.graphics_queue;
+        let present_queue = queues.present_queue;
+        let compute_queue = queues.compute_queue;
 
-        let swapchain_loader = ash::extensions::khr::Swapchain::new(&instance, &logical_device);
-        let (swapchain, swapchain_format, swapchain_extent, swapchain_images) =
-            swapchain::create_swapchain(
-                &instance, &logical_device, physical_device, &surface_loader, surface, &q_indices,
+        let (swapchain_loader, swapchain, swapchain_format, swapchain_extent, swapchain_images, swapchain_image_views) =
+            swapchain::create_swapchain_direct(
+                &instance_ash, &logical_device_ash, chosen_physical_device.physical_device, &surface_loader, surface,
+                chosen_physical_device.queue_family_indices.graphics_family.ok_or("Graphics family index missing")?,
+                chosen_physical_device.queue_family_indices.present_family.ok_or("Present family index missing")?,
                 window_width, window_height, None
             )?;
-        let swapchain_image_views = swapchain::create_image_views(&logical_device, &swapchain_images, swapchain_format)?;
-        let allocator = memory::create_allocator(&instance, physical_device, &logical_device)?;
 
-        // Create Command Pool
-        let pool_create_info = vk::CommandPoolCreateInfo::builder()
-            .flags(vk::CommandPoolCreateFlags::TRANSIENT | vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER)
-            .queue_family_index(q_indices.graphics_family.unwrap());
-        let command_pool = unsafe {
-            logical_device.create_command_pool(&pool_create_info, None)
-                .map_err(|e| format!("Failed to create command pool: {}",e))?
+        let mut allocator = memory::create_allocator(&instance_ash, chosen_physical_device.physical_device, &logical_device_ash)?;
+
+        let vertices = [
+            SimpleVertex { pos: [-0.5, -0.5], color: [1.0,0.0,0.0], tex_coord: [1.0, 0.0] },
+            SimpleVertex { pos: [ 0.5, -0.5], color: [0.0,1.0,0.0], tex_coord: [0.0, 0.0] },
+            SimpleVertex { pos: [ 0.5,  0.5], color: [0.0,0.0,1.0], tex_coord: [0.0, 1.0] },
+            SimpleVertex { pos: [-0.5,  0.5], color: [1.0,1.0,0.0], tex_coord: [1.0, 1.0] },
+        ];
+        let indices: [u16; 6] = [0, 1, 2, 2, 3, 0];
+        let index_count = indices.len() as u32;
+
+        let vertex_buffer_size = (std::mem::size_of_val(&vertices)) as vk::DeviceSize;
+        let (vertex_buffer, mut vertex_buffer_memory_alloc) = memory::create_buffer(
+            &mut allocator, &logical_device_ash, vertex_buffer_size,
+            vk::BufferUsageFlags::VERTEX_BUFFER, MemoryLocation::CpuToGpu,
+        )?;
+        if let Some(slice) = vertex_buffer_memory_alloc.mapped_slice_mut() {
+            let data_ptr = vertices.as_ptr() as *const u8;
+            let data_slice = unsafe { std::slice::from_raw_parts(data_ptr, vertex_buffer_size as usize) };
+            slice[..vertex_buffer_size as usize].copy_from_slice(data_slice);
+        } else {
+             unsafe { logical_device_ash.destroy_buffer(vertex_buffer, None); }
+            return Err("Failed to map vertex buffer memory".to_string());
+        }
+
+        let index_buffer_size = (std::mem::size_of_val(&indices)) as vk::DeviceSize;
+        let (index_buffer, mut index_buffer_memory_alloc) = memory::create_buffer(
+            &mut allocator, &logical_device_ash, index_buffer_size,
+            vk::BufferUsageFlags::INDEX_BUFFER, MemoryLocation::CpuToGpu,
+        )?;
+        if let Some(slice) = index_buffer_memory_alloc.mapped_slice_mut() {
+            let data_ptr = indices.as_ptr() as *const u8;
+            let data_slice = unsafe { std::slice::from_raw_parts(data_ptr, index_buffer_size as usize) };
+            slice[..index_buffer_size as usize].copy_from_slice(data_slice);
+        } else {
+            unsafe {
+                logical_device_ash.destroy_buffer(vertex_buffer, None); allocator.free(vertex_buffer_memory_alloc).ok();
+                logical_device_ash.destroy_buffer(index_buffer, None);
+            }
+            return Err("Failed to map index buffer memory".to_string());
+        }
+
+        let ubo_layout_binding = vk::DescriptorSetLayoutBinding::builder()
+            .binding(0).descriptor_type(vk::DescriptorType::UNIFORM_BUFFER).descriptor_count(1)
+            .stage_flags(vk::ShaderStageFlags::VERTEX);
+        let sampler_layout_binding = vk::DescriptorSetLayoutBinding::builder()
+            .binding(1).descriptor_type(vk::DescriptorType::COMBINED_IMAGE_SAMPLER).descriptor_count(1)
+            .stage_flags(vk::ShaderStageFlags::FRAGMENT);
+        let bindings = [ubo_layout_binding.build(), sampler_layout_binding.build()];
+        let dsl_create_info = vk::DescriptorSetLayoutCreateInfo::builder().bindings(&bindings);
+        let descriptor_set_layout = unsafe { logical_device_ash.create_descriptor_set_layout(&dsl_create_info, None) }?;
+
+        let render_pass = render_pass::create_vulkan_render_pass(&logical_device_ash, swapchain_format)?;
+        let swapchain_framebuffers = swapchain_image_views.iter().map(|&view| {
+            framebuffer::create_vulkan_framebuffer(&logical_device_ash, render_pass, view, swapchain_extent)
+        }).collect::<Result<Vec<_>,_>>()?;
+
+        let set_layouts_for_pipeline = [descriptor_set_layout];
+        let pipeline_layout = pipeline::create_vulkan_pipeline_layout(&logical_device_ash, &set_layouts_for_pipeline, &[])?;
+
+        let logical_device_arc_for_shaders = Arc::new(logical_device_ash.clone());
+        let vert_shader_module = shader::VulkanShaderModule::new_from_file(
+            logical_device_arc_for_shaders.clone(), "assets/shaders/textured_geometry.vert.spv"
+        )?;
+        let frag_shader_module = shader::VulkanShaderModule::new_from_file(
+            logical_device_arc_for_shaders.clone(), "assets/shaders/textured_geometry.frag.spv"
+        )?;
+
+        let logical_device_arc_for_pipeline = Arc::new(logical_device_ash.clone());
+        let binding_description_array = [SimpleVertex::get_binding_description()];
+        let attribute_descriptions_array = SimpleVertex::get_attribute_descriptions();
+
+        let graphics_pipeline_struct = pipeline::VulkanPipeline::new_with_vertex_input(
+            logical_device_arc_for_pipeline.clone(), render_pass, swapchain_extent,
+            &vert_shader_module, &frag_shader_module, pipeline_layout,
+            &binding_description_array, &attribute_descriptions_array,
+        )?;
+        let graphics_pipeline = graphics_pipeline_struct.pipeline;
+
+        let mut uniform_buffers = Vec::with_capacity(MAX_FRAMES_IN_FLIGHT);
+        let mut uniform_buffers_memory = Vec::with_capacity(MAX_FRAMES_IN_FLIGHT);
+        for _ in 0..MAX_FRAMES_IN_FLIGHT {
+            let (buffer, alloc) = memory::create_buffer(
+                &mut allocator, &logical_device_ash, std::mem::size_of::<UniformBufferObject>() as vk::DeviceSize,
+                vk::BufferUsageFlags::UNIFORM_BUFFER, MemoryLocation::CpuToGpu,
+            )?;
+            uniform_buffers.push(buffer);
+            uniform_buffers_memory.push(Some(alloc));
+        }
+
+        let pool_sizes = [
+            vk::DescriptorPoolSize::builder().ty(vk::DescriptorType::UNIFORM_BUFFER).descriptor_count(MAX_FRAMES_IN_FLIGHT as u32).build(),
+            vk::DescriptorPoolSize::builder().ty(vk::DescriptorType::COMBINED_IMAGE_SAMPLER).descriptor_count(MAX_FRAMES_IN_FLIGHT as u32).build(),
+        ];
+        let descriptor_pool_info = vk::DescriptorPoolCreateInfo::builder().pool_sizes(&pool_sizes).max_sets(MAX_FRAMES_IN_FLIGHT as u32).flags(vk::DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET);
+        let descriptor_pool = unsafe { logical_device_ash.create_descriptor_pool(&descriptor_pool_info, None) }?;
+
+        let d_set_layouts_vec = vec![descriptor_set_layout; MAX_FRAMES_IN_FLIGHT];
+        let descriptor_set_alloc_info = vk::DescriptorSetAllocateInfo::builder().descriptor_pool(descriptor_pool).set_layouts(&d_set_layouts_vec);
+        let descriptor_sets = unsafe { logical_device_ash.allocate_descriptor_sets(&descriptor_set_alloc_info) }?;
+
+        // Command Pool must be created before texture upload if it uses it.
+        let q_family_graphics = chosen_physical_device.queue_family_indices.graphics_family.ok_or("Graphics family index missing for command pool")?;
+        let pool_create_info = vk::CommandPoolCreateInfo::builder().flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER).queue_family_index(q_family_graphics);
+        let render_command_pool = unsafe { logical_device_ash.create_command_pool(&pool_create_info, None) }?;
+
+        let mut textures_map = HashMap::new();
+        let default_texture_id;
+        let default_pixel_data: [u8; 4] = [255, 0, 255, 255];
+        let default_gpu_texture = texture_pipeline::upload_shm_buffer_to_texture(
+            &logical_device_ash, &mut allocator, graphics_queue,
+            render_command_pool, // Now render_command_pool is initialized
+            &default_pixel_data, 1, 1, vk::Format::R8G8B8A8_UNORM, false,
+            &pdevice_properties, true,
+        ).map_err(|e| format!("Failed to create default 1x1 texture: {}", e))?;
+        default_texture_id = Some(default_gpu_texture.id);
+        textures_map.insert(default_gpu_texture.id, default_gpu_texture);
+
+        for i in 0..MAX_FRAMES_IN_FLIGHT {
+            let ubo_buffer_info = vk::DescriptorBufferInfo::builder()
+                .buffer(uniform_buffers[i]).offset(0).range(std::mem::size_of::<UniformBufferObject>() as vk::DeviceSize);
+            let bound_texture = textures_map.get(&default_texture_id.unwrap()).ok_or("Default texture not found")?;
+            let image_info = vk::DescriptorImageInfo::builder()
+                .image_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL).image_view(bound_texture.image_view).sampler(bound_texture.sampler);
+            let descriptor_writes = [
+                vk::WriteDescriptorSet::builder().dst_set(descriptor_sets[i]).dst_binding(0).dst_array_element(0)
+                    .descriptor_type(vk::DescriptorType::UNIFORM_BUFFER).buffer_info(std::slice::from_ref(&ubo_buffer_info)).build(),
+                vk::WriteDescriptorSet::builder().dst_set(descriptor_sets[i]).dst_binding(1).dst_array_element(0)
+                    .descriptor_type(vk::DescriptorType::COMBINED_IMAGE_SAMPLER).image_info(std::slice::from_ref(&image_info)).build(),
+            ];
+            unsafe { logical_device_ash.update_descriptor_sets(&descriptor_writes, &[]) };
+        }
+
+        let cmd_buffer_alloc_info = vk::CommandBufferAllocateInfo::builder().command_pool(render_command_pool).level(vk::CommandBufferLevel::PRIMARY).command_buffer_count(MAX_FRAMES_IN_FLIGHT as u32);
+        let render_command_buffers = unsafe { logical_device_ash.allocate_command_buffers(&cmd_buffer_alloc_info) }?;
+
+        let mut image_available_semaphores = Vec::with_capacity(MAX_FRAMES_IN_FLIGHT);
+        let mut render_finished_semaphores = Vec::with_capacity(MAX_FRAMES_IN_FLIGHT);
+        let mut in_flight_fences = Vec::with_capacity(MAX_FRAMES_IN_FLIGHT);
+        let semaphore_info = vk::SemaphoreCreateInfo::builder();
+        let fence_info = vk::FenceCreateInfo::builder().flags(vk::FenceCreateFlags::SIGNALED);
+        for _ in 0..MAX_FRAMES_IN_FLIGHT {
+            image_available_semaphores.push(unsafe { logical_device_ash.create_semaphore(&semaphore_info, None)? });
+            render_finished_semaphores.push(unsafe { logical_device_ash.create_semaphore(&semaphore_info, None)? });
+            in_flight_fences.push(unsafe { logical_device_ash.create_fence(&fence_info, None)? });
+        }
+
+        // --- WP-06 Timestamp Query Pool ---
+        let timestamp_query_pool = if physical_device_properties.limits.timestamp_compute_and_graphics {
+            let query_pool_info = vk::QueryPoolCreateInfo::builder()
+                .query_type(vk::QueryType::TIMESTAMP)
+                .query_count(TIMESTAMP_QUERY_COUNT * MAX_FRAMES_IN_FLIGHT as u32); // 2 timestamps per frame in flight
+            Some(unsafe { logical_device_ash.create_query_pool(&query_pool_info, None)? })
+        } else {
+            eprintln!("Warning: Timestamps not supported on graphics/compute queues by this device.");
+            None
         };
+        // --- End WP-06 ---
 
-        println!("Vulkan Renderer initialized with Texture Pipeline capabilities.");
+        let mut compute_setup = VulkanRenderer::setup_compute_specific_resources(
+            &logical_device_ash, &mut allocator, &pdevice_properties,
+            chosen_physical_device.queue_family_indices.compute_family.unwrap_or(q_family_graphics),
+            descriptor_pool // Pass the main descriptor pool for compute sets for now
+        )?;
+
+        println!("Vulkan Renderer initialized with vertex/index buffers and UBOs for textured geometry rendering.");
         Ok(VulkanRenderer {
-            entry, instance, debug_utils, debug_messenger,
-            surface_loader, surface, physical_device, device: logical_device,
-            graphics_queue, present_queue, swapchain_loader, swapchain,
-            swapchain_images, swapchain_image_views, swapchain_format, swapchain_extent,
-            allocator,
-            command_pool,
-            textures: HashMap::new(),
+            entry, instance: instance_ash, debug_utils, debug_messenger,
+            surface_loader, surface, physical_device: chosen_physical_device.physical_device,
+            device: logical_device_ash, graphics_queue, present_queue, compute_queue,
+            physical_device_properties, // Stored
+            swapchain_loader, swapchain, swapchain_images, swapchain_image_views,
+            swapchain_format, swapchain_extent, allocator,
+            render_command_pool, render_command_buffers,
+            image_available_semaphores, render_finished_semaphores, in_flight_fences,
+            current_frame_index: 0, render_pass,
+            descriptor_set_layout, descriptor_pool,
+            pipeline_layout, graphics_pipeline, swapchain_framebuffers,
+            vertex_buffer, vertex_buffer_memory: Some(vertex_buffer_memory_alloc),
+            index_buffer, index_buffer_memory: Some(index_buffer_memory_alloc),
+            index_count,
+            uniform_buffers, uniform_buffers_memory, descriptor_sets,
+            textures: textures_map, default_texture_id,
+            compute_command_pool: compute_setup.command_pool,
+            compute_command_buffer: compute_setup.command_buffer,
+            compute_descriptor_set_layout: Some(compute_setup.descriptor_set_layout),
+            compute_pipeline_layout: Some(compute_setup.pipeline_layout),
+            compute_pipeline: Some(compute_setup.pipeline),
+            compute_descriptor_set: Some(compute_setup.descriptor_set),
+            compute_storage_image: compute_setup.storage_image,
+            compute_fence: Some(compute_setup.fence),
+            timestamp_query_pool,
         })
     }
 
+    struct ComputeResources { // Renamed from ComputeVulkanRendererResources
+        command_pool: Option<vk::CommandPool>,
+        command_buffer: Option<vk::CommandBuffer>,
+        descriptor_set_layout: vk::DescriptorSetLayout,
+        pipeline_layout: vk::PipelineLayout,
+        pipeline: vk::Pipeline,
+        descriptor_set: vk::DescriptorSet,
+        storage_image: Option<GpuTexture>,
+        fence: vk::Fence,
+    }
+
+    fn setup_compute_specific_resources(
+        device: &ash::Device,
+        allocator: &mut Allocator,
+        pdevice_properties: &vk::PhysicalDeviceProperties,
+        compute_q_family_idx: u32,
+        graphics_descriptor_pool: vk::DescriptorPool, // To allocate compute descriptor set
+    ) -> Result<ComputeResources, String> {
+        let compute_pool_info = vk::CommandPoolCreateInfo::builder()
+            .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER)
+            .queue_family_index(compute_q_family_idx);
+        let compute_command_pool = unsafe { device.create_command_pool(&compute_pool_info, None)? };
+
+        let compute_cb_alloc_info = vk::CommandBufferAllocateInfo::builder()
+            .command_pool(compute_command_pool).level(vk::CommandBufferLevel::PRIMARY).command_buffer_count(1);
+        let compute_command_buffer = unsafe { device.allocate_command_buffers(&compute_cb_alloc_info)?[0] };
+
+        let storage_image_extent = vk::Extent2D { width: 256, height: 256 };
+        let storage_image_format = vk::Format::R8G8B8A8_UNORM;
+        let storage_image_usage = vk::ImageUsageFlags::STORAGE | vk::ImageUsageFlags::SAMPLED | vk::ImageUsageFlags::TRANSFER_SRC | vk::ImageUsageFlags::TRANSFER_DST; // Added TRANSFER_DST for initial clear/write
+
+        // Create a dummy GpuQueue for texture_pipeline function
+        // This is a simplification. Ideally, texture_pipeline wouldn't need a full GpuQueue.
+        let dummy_compute_queue_for_texture_upload = unsafe { device.get_device_queue(compute_q_family_idx, 0) };
+
+        let compute_storage_image_tex = texture_pipeline::upload_shm_buffer_to_texture(
+            device, allocator, dummy_compute_queue_for_texture_upload,
+            compute_command_pool, &vec![0u8; (storage_image_extent.width * storage_image_extent.height * 4) as usize],
+            storage_image_extent.width, storage_image_extent.height, storage_image_format, false,
+            pdevice_properties, false
+        ).map_err(|e| format!("Failed to create compute storage image: {}", e))?;
+
+        let storage_image_dsl_binding = vk::DescriptorSetLayoutBinding::builder()
+            .binding(0).descriptor_type(vk::DescriptorType::STORAGE_IMAGE)
+            .descriptor_count(1).stage_flags(vk::ShaderStageFlags::COMPUTE);
+        let compute_dsl_info = vk::DescriptorSetLayoutCreateInfo::builder().bindings(std::slice::from_ref(&storage_image_dsl_binding));
+        let compute_dsl = unsafe { device.create_descriptor_set_layout(&compute_dsl_info, None)? };
+
+        let compute_pipeline_layout = pipeline::create_vulkan_pipeline_layout(device, &[compute_dsl], &[])?;
+
+        let compute_shader_module = shader::VulkanShaderModule::new_from_file(
+            Arc::new(device.clone()), "assets/shaders/compute_shader.comp.spv"
+        )?;
+
+        let compute_stage_info = vk::PipelineShaderStageCreateInfo::builder()
+            .stage(vk::ShaderStageFlags::COMPUTE).module(compute_shader_module.handle())
+            .name(std::ffi::CStr::from_bytes_with_nul(b"main\0").unwrap());
+        let compute_pipeline_info = vk::ComputePipelineCreateInfo::builder()
+            .stage(compute_stage_info.build()).layout(compute_pipeline_layout);
+        let compute_pipeline = unsafe {
+            device.create_compute_pipelines(vk::PipelineCache::null(), &[compute_pipeline_info.build()], None)
+                .map_err(|(_, err)| format!("Failed to create compute pipeline: {:?}", err))?[0]
+        };
+
+        let compute_d_set_layouts = [compute_dsl];
+        let compute_d_set_alloc_info = vk::DescriptorSetAllocateInfo::builder()
+            .descriptor_pool(graphics_descriptor_pool) // Use the main graphics pool for this single set
+            .set_layouts(&compute_d_set_layouts);
+        let compute_descriptor_set = unsafe { device.allocate_descriptor_sets(&compute_d_set_alloc_info)?[0] };
+
+        let storage_image_info = vk::DescriptorImageInfo::builder()
+            .image_layout(vk::ImageLayout::GENERAL)
+            .image_view(compute_storage_image_tex.image_view);
+        let compute_write = vk::WriteDescriptorSet::builder()
+            .dst_set(compute_descriptor_set).dst_binding(0)
+            .descriptor_type(vk::DescriptorType::STORAGE_IMAGE).image_info(std::slice::from_ref(&storage_image_info));
+        unsafe { device.update_descriptor_sets(&[compute_write.build()], &[]) };
+
+        let compute_fence_info = vk::FenceCreateInfo::builder();
+        let compute_fence = unsafe { device.create_fence(&compute_fence_info, None)? };
+
+        Ok(ComputeResources {
+            command_pool: Some(compute_command_pool),
+            command_buffer: Some(compute_command_buffer),
+            descriptor_set_layout: compute_dsl,
+            pipeline_layout: compute_pipeline_layout,
+            pipeline: compute_pipeline,
+            descriptor_set: compute_descriptor_set,
+            storage_image: Some(compute_storage_image_tex),
+            fence: compute_fence,
+        })
+    }
+
+
+    fn record_main_command_buffer(
+        &self,
+        command_buffer: vk::CommandBuffer,
+        framebuffer: vk::Framebuffer,
+        clear_color_value: [f32; 4],
+        current_frame_idx: usize,
+    ) -> Result<(), String> {
+        unsafe {
+            self.device.reset_command_buffer(command_buffer, vk::CommandBufferResetFlags::empty())?;
+            let begin_info = vk::CommandBufferBeginInfo::builder().flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
+            self.device.begin_command_buffer(command_buffer, &begin_info)?;
+
+            // --- WP-06 Timestamp Start ---
+            if let Some(pool) = self.timestamp_query_pool {
+                 // Reset queries for the current frame in flight. Query indices are (current_frame_idx * 2) and (current_frame_idx * 2 + 1)
+                self.device.cmd_reset_query_pool(command_buffer, pool, (current_frame_idx * TIMESTAMP_QUERY_COUNT as usize) as u32, TIMESTAMP_QUERY_COUNT);
+                self.device.cmd_write_timestamp(command_buffer, vk::PipelineStageFlags::TOP_OF_PIPE, pool, (current_frame_idx * TIMESTAMP_QUERY_COUNT as usize) as u32);
+            }
+            // --- End WP-06 ---
+
+            let clear_values = [vk::ClearValue { color: vk::ClearColorValue { float32: clear_color_value } }];
+            let render_pass_begin_info = vk::RenderPassBeginInfo::builder()
+                .render_pass(self.render_pass).framebuffer(framebuffer)
+                .render_area(vk::Rect2D { offset: vk::Offset2D { x: 0, y: 0 }, extent: self.swapchain_extent, })
+                .clear_values(&clear_values);
+
+            self.device.cmd_begin_render_pass(command_buffer, &render_pass_begin_info, vk::SubpassContents::INLINE);
+            self.device.cmd_bind_pipeline(command_buffer, vk::PipelineBindPoint::GRAPHICS, self.graphics_pipeline);
+
+            let viewport = vk::Viewport {
+                x: 0.0, y: 0.0, width: self.swapchain_extent.width as f32, height: self.swapchain_extent.height as f32,
+                min_depth: 0.0, max_depth: 1.0,
+            };
+            self.device.cmd_set_viewport(command_buffer, 0, &[viewport]);
+            let scissor = vk::Rect2D { offset: vk::Offset2D { x: 0, y: 0 }, extent: self.swapchain_extent };
+            self.device.cmd_set_scissor(command_buffer, 0, &[scissor]);
+
+            let vertex_buffers = [self.vertex_buffer];
+            let offsets = [0_u64];
+            self.device.cmd_bind_vertex_buffers(command_buffer, 0, &vertex_buffers, &offsets);
+            self.device.cmd_bind_index_buffer(command_buffer, self.index_buffer, 0, vk::IndexType::UINT16);
+            self.device.cmd_bind_descriptor_sets(
+                command_buffer, vk::PipelineBindPoint::GRAPHICS, self.pipeline_layout, 0,
+                &[self.descriptor_sets[current_frame_idx]], &[],
+            );
+            self.device.cmd_draw_indexed(command_buffer, self.index_count, 1, 0, 0, 0);
+            self.device.cmd_end_render_pass(command_buffer);
+
+            // --- WP-06 Timestamp End ---
+            if let Some(pool) = self.timestamp_query_pool {
+                self.device.cmd_write_timestamp(command_buffer, vk::PipelineStageFlags::BOTTOM_OF_PIPE, pool, (current_frame_idx * TIMESTAMP_QUERY_COUNT as usize + 1) as u32);
+            }
+            // --- End WP-06 ---
+
+            self.device.end_command_buffer(command_buffer)?;
+        }
+        Ok(())
+    }
+
+    fn update_uniform_buffer(&mut self, current_image_index: usize) -> Result<(), String> {
+        let time = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_secs_f32();
+        let model = glam::Mat4::from_rotation_z(time * std::f32::consts::FRAC_PI_2 * 0.2);
+        let view = glam::Mat4::look_at_rh(glam::vec3(0.0, 0.0, 1.5), glam::Vec3::ZERO, glam::Vec3::Y);
+        let mut proj = glam::Mat4::perspective_rh_gl(
+            60.0_f32.to_radians(), self.swapchain_extent.width as f32 / self.swapchain_extent.height as f32, 0.1, 10.0
+        );
+        proj.y_axis.y *= -1.0;
+        let ubo = UniformBufferObject { model: model.to_cols_array_2d(), view: view.to_cols_array_2d(), proj: proj.to_cols_array_2d() };
+
+        if let Some(Some(alloc)) = self.uniform_buffers_memory.get_mut(current_image_index) {
+            if let Some(mapped_slice) = alloc.mapped_slice_mut() {
+                let ubo_size = std::mem::size_of::<UniformBufferObject>();
+                let ubo_ptr = &ubo as *const UniformBufferObject as *const u8;
+                let ubo_data_slice = unsafe { std::slice::from_raw_parts(ubo_ptr, ubo_size) };
+                mapped_slice[..ubo_size].copy_from_slice(ubo_data_slice);
+            } else { return Err(format!("Failed to map uniform buffer memory for frame index {}", current_image_index)); }
+        } else { return Err(format!("Uniform buffer memory not found for frame index {}", current_image_index)); }
+        Ok(())
+    }
+
+    pub fn draw_frame(&mut self, clear_color: [f32; 4]) -> Result<bool, String> {
+        let current_frame_sync_idx = self.current_frame_index;
+        let fence = self.in_flight_fences[current_frame_sync_idx];
+        let image_available_semaphore = self.image_available_semaphores[current_frame_sync_idx];
+        let render_finished_semaphore = self.render_finished_semaphores[current_frame_sync_idx];
+        let command_buffer = self.render_command_buffers[current_frame_sync_idx];
+
+        unsafe { self.device.wait_for_fences(&[fence], true, u64::MAX)? };
+        let acquire_result = unsafe { self.swapchain_loader.acquire_next_image(self.swapchain, u64::MAX, image_available_semaphore, vk::Fence::null()) };
+        let (image_index_u32, mut needs_recreate) = match acquire_result {
+            Ok((index, suboptimal)) => (index, suboptimal),
+            Err(vk::Result::ERROR_OUT_OF_DATE_KHR) => return Ok(true),
+            Err(e) => return Err(format!("Failed to acquire swapchain image: {}", e)),
+        };
+        let image_index = image_index_u32 as usize;
+        self.update_uniform_buffer(current_frame_sync_idx)?;
+        unsafe { self.device.reset_fences(&[fence])? };
+        self.record_main_command_buffer(command_buffer, self.swapchain_framebuffers[image_index], clear_color, current_frame_sync_idx)?;
+
+        let wait_semaphores = [image_available_semaphore];
+        let wait_stages = [vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT];
+        let signal_semaphores = [render_finished_semaphore];
+        let submit_infos = [vk::SubmitInfo::builder()
+            .wait_semaphores(&wait_semaphores).wait_dst_stage_mask(&wait_stages)
+            .command_buffers(&[command_buffer]).signal_semaphores(&signal_semaphores).build()];
+        unsafe { self.device.queue_submit(self.graphics_queue, &submit_infos, fence)? };
+
+        let swapchains = [self.swapchain];
+        let image_indices_present = [image_index_u32];
+        let present_info = vk::PresentInfoKHR::builder()
+            .wait_semaphores(&signal_semaphores).swapchains(&swapchains).image_indices(&image_indices_present);
+        let present_result = unsafe { self.swapchain_loader.queue_present(self.present_queue, &present_info) };
+        match present_result {
+            Ok(suboptimal) => if suboptimal { needs_recreate = true; },
+            Err(vk::Result::ERROR_OUT_OF_DATE_KHR) | Err(vk::Result::SUBOPTIMAL_KHR) => needs_recreate = true,
+            Err(e) => return Err(format!("Failed to present swapchain image: {}", e)),
+        }
+        self.current_frame_index = (self.current_frame_index + 1) % MAX_FRAMES_IN_FLIGHT;
+        Ok(needs_recreate)
+    }
+
+    pub fn dispatch_compute_shader(&mut self) -> Result<(), String> {
+        let (cmd_pool, cmd_buffer, fence, pipeline, layout, d_set, storage_image_ref) =
+        match (
+            self.compute_command_pool, self.compute_command_buffer, self.compute_fence,
+            self.compute_pipeline, self.compute_pipeline_layout, self.compute_descriptor_set,
+            self.compute_storage_image.as_ref() // Borrow storage image
+        ) {
+            (Some(pool), Some(cb), Some(f), Some(p), Some(pl), Some(ds), Some(si)) => (pool, cb, f, p, pl, ds, si),
+            _ => return Err("Compute resources not properly initialized for dispatch.".to_string()),
+        };
+
+        let compute_q = self.compute_queue.unwrap_or(self.graphics_queue);
+
+        unsafe {
+            self.device.wait_for_fences(&[fence], true, u64::MAX)?;
+            self.device.reset_fences(&[fence])?;
+            self.device.reset_command_buffer(cmd_buffer, vk::CommandBufferResetFlags::empty())?;
+
+            let begin_info = vk::CommandBufferBeginInfo::builder().flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
+            self.device.begin_command_buffer(cmd_buffer, &begin_info)?;
+
+            // --- Transition storage image to GENERAL for compute write ---
+            // This assumes the image was created and is in some initial layout (e.g., UNDEFINED or SHADER_READ_ONLY_OPTIMAL)
+            // A more robust system would track current layout.
+            let pre_compute_barrier = vk::ImageMemoryBarrier::builder()
+                .old_layout(storage_image_ref.layout) // Use GpuTexture's current layout
+                .new_layout(vk::ImageLayout::GENERAL)
+                .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+                .dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+                .image(storage_image_ref.image)
+                .subresource_range(vk::ImageSubresourceRange{ aspect_mask: vk::ImageAspectFlags::COLOR, base_mip_level: 0, level_count: 1, base_array_layer: 0, layer_count: 1})
+                .src_access_mask(vk::AccessFlags::empty()) // Or specific if coming from another operation
+                .dst_access_mask(vk::AccessFlags::SHADER_WRITE);
+
+            self.device.cmd_pipeline_barrier(cmd_buffer,
+                vk::PipelineStageFlags::TOP_OF_PIPE, // Or previous stage
+                vk::PipelineStageFlags::COMPUTE_SHADER,
+                vk::DependencyFlags::empty(), &[], &[], &[pre_compute_barrier.build()]);
+            // --- End Transition ---
+
+
+            self.device.cmd_bind_pipeline(cmd_buffer, vk::PipelineBindPoint::COMPUTE, pipeline);
+            self.device.cmd_bind_descriptor_sets(cmd_buffer, vk::PipelineBindPoint::COMPUTE, layout, 0, &[d_set], &[]);
+
+            let group_x = (storage_image_ref.extent.width + 15) / 16;
+            let group_y = (storage_image_ref.extent.height + 15) / 16;
+            self.device.cmd_dispatch(cmd_buffer, group_x, group_y, 1);
+
+            // --- Barrier after compute write, before potential read ---
+            let post_compute_barrier = vk::ImageMemoryBarrier::builder()
+                .old_layout(vk::ImageLayout::GENERAL)
+                .new_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL) // Example: prepare for sampling
+                .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+                .dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+                .image(storage_image_ref.image)
+                .subresource_range(vk::ImageSubresourceRange{ aspect_mask: vk::ImageAspectFlags::COLOR, base_mip_level: 0, level_count: 1, base_array_layer: 0, layer_count: 1})
+                .src_access_mask(vk::AccessFlags::SHADER_WRITE)
+                .dst_access_mask(vk::AccessFlags::SHADER_READ); // Example for reading in fragment shader
+
+            self.device.cmd_pipeline_barrier(cmd_buffer,
+                vk::PipelineStageFlags::COMPUTE_SHADER,
+                vk::PipelineStageFlags::FRAGMENT_SHADER, // Example stage
+                vk::DependencyFlags::empty(), &[], &[], &[post_compute_barrier.build()]);
+            // Update the GpuTexture's layout state if it's tracked
+            // self.compute_storage_image.as_mut().unwrap().layout = vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL;
+            // --- End Barrier ---
+
+
+            self.device.end_command_buffer(cmd_buffer)?;
+
+            let submit_info = vk::SubmitInfo::builder().command_buffers(&[cmd_buffer]);
+            self.device.queue_submit(compute_q, &[submit_info.build()], fence)?;
+        }
+        // To make the result visible or usable by CPU/other GPU operations,
+        // one would typically wait on the `compute_fence` here or elsewhere.
+        // For example:
+        // unsafe { self.device.wait_for_fences(&[fence], true, u64::MAX)?; }
+        // And then potentially read back data from compute_storage_image if needed.
+        Ok(())
+    }
+
+
     pub fn upload_texture_from_data(
-        &mut self,
-        pixel_data: &[u8],
-        width: u32,
-        height: u32,
-        format: vk::Format,
-        generate_mipmaps: bool, // New parameter
+        &mut self, pixel_data: &[u8], width: u32, height: u32,
+        format: vk::Format, generate_mipmaps: bool,
     ) -> Result<TextureId, String> {
+        let pdevice_properties = unsafe { self.instance.get_physical_device_properties(self.physical_device) };
+        let enable_anisotropy = true;
         let gpu_texture = texture_pipeline::upload_shm_buffer_to_texture(
-            &self.device,
-            &mut self.allocator,
-            self.graphics_queue,
-            self.command_pool,
-            pixel_data,
-            width,
-            height,
-            format,
-            generate_mipmaps, // Pass it through
+            &self.device, &mut self.allocator, self.graphics_queue,
+            self.render_command_pool, pixel_data, width, height, format, generate_mipmaps,
+            &pdevice_properties, enable_anisotropy,
         )?;
         let id = gpu_texture.id;
         self.textures.insert(id, gpu_texture);
@@ -150,109 +707,171 @@ impl VulkanRenderer {
 
     pub fn destroy_texture(&mut self, id: TextureId) -> Result<(), String>{
         if let Some(mut texture) = self.textures.remove(&id) {
-            // Pass self.device and self.allocator by reference
             texture.destroy(&self.device, &mut self.allocator);
             Ok(())
-        } else {
-            Err(format!("TextureId {:?} not found for destruction.", id))
-        }
+        } else { Err(format!("TextureId {:?} not found for destruction.", id)) }
     }
 
     pub fn import_texture_from_dmabuf(
-        &mut self,
-        fd: RawFd, // From wayland client (zwp_linux_buffer_params_v1)
-        width: u32,
-        height: u32,
-        format: vk::Format, // Vulkan format
-        drm_modifier: Option<u64>,
-        allocation_size: vk::DeviceSize, // Actual size of the DMA-BUF
+        &mut self, fd: RawFd, width: u32, height: u32,
+        format: vk::Format, drm_modifier: Option<u64>, allocation_size: vk::DeviceSize,
     ) -> Result<TextureId, String> {
-        // 1. Determine memory_type_index (using placeholder for now)
-        let memory_type_index = dmabuf::get_memory_type_index_for_dmabuf_placeholder(
-            &self.instance,
-            self.physical_device,
-        )?;
-
-        let import_options = DmaBufImportOptions {
-            fd,
-            width,
-            height,
-            format,
-            drm_format_modifier,
-            allocation_size,
-            memory_type_index,
-        };
-
-        let (image, device_memory, image_view) =
-            dmabuf::import_dmabuf_as_image(&mut self.allocator, &self.device, &import_options)?;
-
+        let memory_type_index = dmabuf::get_memory_type_index_for_dmabuf_placeholder(&self.instance, self.physical_device)?;
+        let import_options = DmaBufImportOptions {fd, width, height, format, drm_modifier, allocation_size, memory_type_index};
+        let (image, device_memory, image_view) = dmabuf::import_dmabuf_as_image(&mut self.allocator, &self.device, &import_options)?;
+        let pdevice_properties = unsafe { self.instance.get_physical_device_properties(self.physical_device) };
+        let sampler = texture_pipeline::create_texture_sampler(&self.device, &pdevice_properties, 1, true)?;
         let texture_id = TextureId::new();
         let gpu_texture = GpuTexture {
-            id: texture_id,
-            image,
-            image_view,
-            allocation: None, // Not allocated by gpu-allocator
-            memory: Some(device_memory), // Store the imported vk::DeviceMemory
-            format,
-            extent: vk::Extent2D { width, height },
-            layout: vk::ImageLayout::UNDEFINED,
+            id: texture_id, image, image_view, allocation: None, memory: Some(device_memory),
+            format, extent: vk::Extent2D { width, height }, layout: vk::ImageLayout::UNDEFINED,
+            mip_levels: 1, sampler,
         };
-
         self.textures.insert(texture_id, gpu_texture);
-
-        // Perform initial layout transition UNDEFINED -> SHADER_READ_ONLY_OPTIMAL
-        let temp_cmd_buffer = command_buffer::begin_single_time_commands(&self.device, self.command_pool)?;
+        let temp_cmd_buffer = command_buffer::begin_single_time_commands(&self.device, self.render_command_pool)?;
         texture_pipeline::transition_image_layout(
-            &self.device,
-            temp_cmd_buffer,
-            image, // this is the vk::Image handle from import_dmabuf_as_image
-            vk::ImageLayout::UNDEFINED,
-            vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+            &self.device, temp_cmd_buffer, image, vk::ImageLayout::UNDEFINED, vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL, 0, 1,
         );
-        command_buffer::end_single_time_commands(&self.device, self.command_pool, temp_cmd_buffer, self.graphics_queue)?;
-
-        // Update the texture's layout in our map
-        if let Some(tex) = self.textures.get_mut(&texture_id) {
-            tex.layout = vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL;
-        }
-
+        command_buffer::end_single_time_commands(&self.device, self.render_command_pool, temp_cmd_buffer, self.graphics_queue)?;
+        if let Some(tex) = self.textures.get_mut(&texture_id) { tex.layout = vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL; }
         Ok(texture_id)
     }
 
     pub fn update_texture_region_from_data(
-        &mut self,
-        texture_id: TextureId,
-        region: vk::Rect2D,
-        pixel_data: &[u8],
+        &mut self, texture_id: TextureId, region: vk::Rect2D, pixel_data: &[u8],
     ) -> Result<(), String> {
-        let gpu_texture = self.textures.get_mut(&texture_id)
-            .ok_or_else(|| format!("TextureId {:?} not found for update.", texture_id))?;
-
-        // Basic validation (more can be added)
+        let gpu_texture = self.textures.get_mut(&texture_id).ok_or_else(|| format!("TextureId {:?} not found for update.", texture_id))?;
         if gpu_texture.mip_levels > 1 {
-            // Log a warning or handle as an error if mipmaps should be regenerated
             println!("Warning: Updating region of a mipmapped texture (TextureId: {:?}). Only base level (0) is updated. Mipmaps will be stale.", texture_id);
         }
-
         texture_pipeline::update_texture_region(
-            &self.device,
-            &mut self.allocator,
-            self.graphics_queue,
-            self.command_pool,
-            gpu_texture,
-            region,
-            pixel_data,
+            &self.device, &mut self.allocator, self.graphics_queue, self.render_command_pool, gpu_texture, region, pixel_data,
         )
     }
+
+    // --- WP-06: Timestamp Query Result ---
+    /// Attempts to get the duration of the last fully rendered frame using timestamp queries.
+    /// Returns `Ok(None)` if results are not yet available or timestamps are not supported.
+    /// Returns `Ok(Some(duration_ms))` if successful.
+    pub fn get_last_frame_gpu_duration_ms(&self) -> Result<Option<f32>, String> {
+        if let Some(pool) = self.timestamp_query_pool {
+            // Determine which set of queries to fetch based on current_frame_index.
+            // The queries for the *last completed frame* would be for (current_frame_index - 1 + MAX_FRAMES_IN_FLIGHT) % MAX_FRAMES_IN_FLIGHT.
+            // For simplicity, let's assume we are querying for the set of timestamps that *should* be ready.
+            // A robust implementation would track which query sets are pending/available.
+            // We query for the *previous* frame's set of timestamps, as the current one is likely still in flight.
+            let query_idx_for_last_completed_frame = (self.current_frame_index.wrapping_sub(1) + MAX_FRAMES_IN_FLIGHT) % MAX_FRAMES_IN_FLIGHT;
+            let first_query = (query_idx_for_last_completed_frame * TIMESTAMP_QUERY_COUNT as usize) as u32;
+
+            let mut query_results = vec![0u64; TIMESTAMP_QUERY_COUNT as usize];
+            let status = unsafe {
+                self.device.get_query_pool_results(
+                    pool,
+                    first_query, // first_query
+                    TIMESTAMP_QUERY_COUNT, // query_count
+                    &mut query_results,
+                    vk::QueryResultFlags::BITS_64 | vk::QueryResultFlags::WAIT, // Wait for results
+                )
+            };
+
+            match status {
+                Ok(()) => { // VK_SUCCESS means results are available
+                    let start_time = query_results[0];
+                    let end_time = query_results[1];
+                    if start_time == 0 || end_time == 0 || end_time < start_time {
+                        // Timestamps might not have been written correctly or device doesn't support them properly.
+                        // Or queries were reset and not written yet for this slot.
+                        return Ok(None);
+                    }
+                    let duration_ticks = end_time - start_time;
+                    let nanoseconds_per_tick = self.physical_device_properties.limits.timestamp_period;
+                    let duration_ns = duration_ticks as f64 * nanoseconds_per_tick as f64;
+                    Ok(Some((duration_ns / 1_000_000.0) as f32)) // Convert to milliseconds
+                }
+                Err(vk::Result::NOT_READY) => Ok(None), // Results not yet available
+                Err(e) => Err(format!("Failed to get query pool results: {}", e)),
+            }
+        } else {
+            Ok(None) // Timestamp queries not enabled/supported
+        }
+    }
+    // --- End WP-06 ---
 }
+
+
+// Helper struct for returning compute-specific resources from setup function.
+// This avoids making VulkanRenderer::new too complex if compute setup is extensive.
+struct ComputeResources { // Renamed from ComputeVulkanRendererResources
+    command_pool: Option<vk::CommandPool>,
+    command_buffer: Option<vk::CommandBuffer>,
+    descriptor_set_layout: vk::DescriptorSetLayout,
+    pipeline_layout: vk::PipelineLayout,
+    pipeline: vk::Pipeline,
+    descriptor_set: vk::DescriptorSet,
+    storage_image: Option<GpuTexture>,
+    fence: vk::Fence,
+}
+
 
 impl Drop for VulkanRenderer {
     fn drop(&mut self) {
         unsafe {
-            // Wait for device to be idle before destroying resources
             if self.device.device_wait_idle().is_err() {
                 eprintln!("Error waiting for device idle in VulkanRenderer drop");
             }
+
+            self.device.destroy_buffer(self.vertex_buffer, None);
+            if let Some(alloc) = self.vertex_buffer_memory.take() {
+                self.allocator.free(alloc).unwrap_or_else(|e| eprintln!("Failed to free vertex buffer memory: {:?}", e));
+            }
+            self.device.destroy_buffer(self.index_buffer, None);
+            if let Some(alloc) = self.index_buffer_memory.take() {
+                self.allocator.free(alloc).unwrap_or_else(|e| eprintln!("Failed to free index buffer memory: {:?}", e));
+            }
+
+            for i in 0..MAX_FRAMES_IN_FLIGHT {
+                self.device.destroy_buffer(self.uniform_buffers[i], None);
+                if let Some(alloc) = self.uniform_buffers_memory[i].take() {
+                     self.allocator.free(alloc).unwrap_or_else(|e| eprintln!("Failed to free UBO memory for frame {}: {:?}", i, e));
+                }
+            }
+            self.device.destroy_descriptor_pool(self.descriptor_pool, None);
+            self.device.destroy_descriptor_set_layout(self.descriptor_set_layout, None);
+
+            if let Some(pipeline) = self.compute_pipeline.take() { self.device.destroy_pipeline(pipeline, None); }
+            if let Some(layout) = self.compute_pipeline_layout.take() { self.device.destroy_pipeline_layout(layout, None); }
+            if let Some(dsl) = self.compute_descriptor_set_layout.take() { self.device.destroy_descriptor_set_layout(dsl, None); }
+            if let Some(mut image) = self.compute_storage_image.take() { image.destroy(&self.device, &mut self.allocator); } // compute_descriptor_set freed with pool
+            if let Some(fence) = self.compute_fence.take() { self.device.destroy_fence(fence, None); }
+            if let Some(cb) = self.compute_command_buffer.take() {
+                if let Some(pool) = self.compute_command_pool {
+                    self.device.free_command_buffers(pool, &[cb]);
+                }
+            }
+            if let Some(pool) = self.compute_command_pool.take() { self.device.destroy_command_pool(pool, None); }
+
+
+            for &framebuffer in self.swapchain_framebuffers.iter() {
+                self.device.destroy_framebuffer(framebuffer, None);
+            }
+            self.device.destroy_pipeline(self.graphics_pipeline, None);
+            self.device.destroy_pipeline_layout(self.pipeline_layout, None);
+            self.device.destroy_render_pass(self.render_pass, None);
+
+            // --- WP-06 Timestamp Query Pool Cleanup ---
+            if let Some(pool) = self.timestamp_query_pool.take() {
+                self.device.destroy_query_pool(pool, None);
+            }
+            // --- End WP-06 ---
+
+            for i in 0..MAX_FRAMES_IN_FLIGHT {
+                self.device.destroy_semaphore(self.image_available_semaphores[i], None);
+                self.device.destroy_semaphore(self.render_finished_semaphores[i], None);
+                self.device.destroy_fence(self.in_flight_fences[i], None);
+            }
+
+            self.device.free_command_buffers(self.render_command_pool, &self.render_command_buffers);
+            self.device.destroy_command_pool(self.render_command_pool, None);
 
             let texture_ids: Vec<TextureId> = self.textures.keys().cloned().collect();
             for id in texture_ids {
@@ -260,8 +879,6 @@ impl Drop for VulkanRenderer {
                     texture.destroy(&self.device, &mut self.allocator);
                 }
             }
-
-            self.device.destroy_command_pool(self.command_pool, None);
 
             for &image_view in self.swapchain_image_views.iter() {
                 self.device.destroy_image_view(image_view, None);
@@ -274,15 +891,28 @@ impl Drop for VulkanRenderer {
                 loader.destroy_debug_utils_messenger(messenger, None);
             }
             self.instance.destroy_instance(None);
-            println!("Vulkan Renderer dropped (with texture and command pool cleanup).");
+            println!("Vulkan Renderer dropped comprehensively.");
         }
     }
 }
 
-// Implement RendererInterface for VulkanRenderer (placeholders for now)
 impl RendererInterface for VulkanRenderer {
-    fn begin_frame(&mut self) { println!("VulkanRenderer: Beginning frame"); }
-    fn submit_frame(&mut self) { println!("VulkanRenderer: Submitting frame"); }
-    fn present(&mut self) { println!("VulkanRenderer: Presenting frame"); }
-    fn resize(&mut self, _new_size: Size2D) { println!("VulkanRenderer: Resizing"); }
+    fn begin_frame(&mut self) {}
+    fn submit_frame(&mut self) {}
+    fn present(&mut self) {
+        let clear_color = [0.0, 0.0, 0.0, 1.0];
+        match self.draw_frame(clear_color) {
+            Ok(needs_recreate) => {
+                if needs_recreate {
+                    // Handle swapchain recreation (e.g., by calling self.resize with current dimensions)
+                    println!("Swapchain needs recreation after present.");
+                    // self.resize(Size2D { width: self.swapchain_extent.width, height: self.swapchain_extent.height });
+                }
+            }
+            Err(e) => eprintln!("Error during present (draw_frame): {}", e),
+        }
+    }
+    fn resize(&mut self, _new_size: Size2D) {
+        println!("VulkanRenderer: Resizing (TODO: Implement swapchain recreation)");
+    }
 }

--- a/novade-system/src/renderers/vulkan/pipeline.rs
+++ b/novade-system/src/renderers/vulkan/pipeline.rs
@@ -5,187 +5,215 @@ use super::shader::VulkanShaderModule; // Assuming VulkanShaderModule is in supe
 // ANCHOR: VulkanPipeline Struct Definition
 pub struct VulkanPipeline {
     device: Arc<AshDevice>,
-    pipeline_layout: vk::PipelineLayout,
-    // descriptor_set_layouts: Vec<vk::DescriptorSetLayout>, // For future use
-    pipeline: vk::Pipeline,
+    pub pipeline_layout: vk::PipelineLayout, // Made public for binding descriptor sets
+    // pub descriptor_set_layouts: Vec<vk::DescriptorSetLayout>, // Store if managed by VulkanPipeline
+    pub pipeline: vk::Pipeline, // Made public for binding in command buffer
 }
+
+/// Creates a Vulkan Pipeline Layout.
+///
+/// The pipeline layout object defines the layout of resources (descriptor sets) and push constants
+/// that can be accessed by a pipeline. It is created based on descriptor set layouts and
+/// push constant ranges.
+///
+/// This function aligns with `Rendering Vulkan.md` (Spec 6.2 - Pipeline-Layout-Definition).
+///
+/// # Arguments
+/// * `device`: A reference to the logical `ash::Device`.
+/// * `set_layouts`: A slice of `vk::DescriptorSetLayout` handles. For a minimal pipeline
+///   (like in WP-303 for a clear screen), this slice would be empty.
+/// * `push_constant_ranges`: A slice of `vk::PushConstantRange`. For a minimal pipeline,
+///   this slice would also be empty.
+///
+/// # Returns
+/// A `Result` containing the created `vk::PipelineLayout` handle, or an error string
+/// if creation fails.
+///
+/// # `Rendering Vulkan.md` Specification Mapping (Spec 6.2):
+/// - `VkDescriptorSetLayoutBinding` / `VkDescriptorSetLayoutCreateInfo`: Assumed to be handled by
+///   the caller when creating the `VkDescriptorSetLayout` objects passed in `set_layouts`.
+/// - `VkPushConstantRange`: Passed directly via `push_constant_ranges`.
+/// - `VkPipelineLayoutCreateInfo`: Configured with the provided `set_layouts` and `push_constant_ranges`.
+pub fn create_vulkan_pipeline_layout(
+    device: &AshDevice,
+    set_layouts: &[vk::DescriptorSetLayout],
+/// The pipeline layout defines the interface between shader stages and shader resources
+/// (like descriptor sets and push constants).
+/// Aligns with `Rendering Vulkan.md` (Spec 6.2).
+///
+/// # Arguments
+/// * `device`: A reference to the logical `ash::Device`.
+/// * `set_layouts`: A slice of `vk::DescriptorSetLayout` handles to be included in the pipeline layout.
+///   For a minimal pipeline (WP-303), this would be empty.
+/// * `push_constant_ranges`: A slice of `vk::PushConstantRange` defining push constant blocks.
+///   For a minimal pipeline, this would be empty.
+///
+/// # Returns
+/// A `Result` containing the created `vk::PipelineLayout` or an error string on failure.
+pub fn create_vulkan_pipeline_layout(
+    device: &AshDevice,
+    set_layouts: &[vk::DescriptorSetLayout],
+    push_constant_ranges: &[vk::PushConstantRange],
+) -> Result<vk::PipelineLayout, String> {
+    let pipeline_layout_create_info = vk::PipelineLayoutCreateInfo::builder()
+        .set_layouts(set_layouts)
+        .push_constant_ranges(push_constant_ranges);
+
+    unsafe {
+        device.create_pipeline_layout(&pipeline_layout_create_info, None)
+    }
+    .map_err(|e| format!("Failed to create pipeline layout: {}", e))
+}
+
 
 // ANCHOR: VulkanPipeline Implementation
 impl VulkanPipeline {
-    pub fn new(
+    /// Creates a new `VulkanPipeline` for graphics operations, configured for minimal rendering.
+    ///
+    /// This constructor sets up a graphics pipeline tailored for the "first visible output"
+    /// stage (WP-303). Key characteristics of this minimal pipeline include:
+    /// - No vertex input attributes or bindings (vertices are generated in the shader or not used).
+    /// - Expects simple vertex and fragment shaders (e.g., for a full-screen triangle or fixed color output).
+    /// - Utilizes dynamic states for viewport and scissor, allowing them to be set at command buffer recording time.
+    /// - Basic rasterization settings (e.g., fill mode, no culling).
+    /// - No multisampling.
+    /// - Depth and stencil tests are disabled.
+    /// - Basic color blending (typically opaque).
+    ///
+    /// This method aligns with `Rendering Vulkan.md` (Spec 6.4 - Graphics-Pipeline-Erstellung).
+    ///
+    /// # Arguments
+    /// * `device`: An `Arc<AshDevice>` reference to the logical device.
+    /// * `render_pass`: The `vk::RenderPass` with which this pipeline must be compatible.
+    /// * `_swapchain_extent`: The `vk::Extent2D` of the swapchain. While passed, it's not directly
+    ///   used in pipeline creation if viewport and scissor are dynamic states (which they are here).
+    ///   It's useful context for understanding the target dimensions.
+    /// * `vert_shader_module`: A reference to the `VulkanShaderModule` for the vertex shader.
+    /// * `frag_shader_module`: A reference to the `VulkanShaderModule` for the fragment shader.
+    /// * `pipeline_layout`: The `vk::PipelineLayout` for this pipeline. For the minimal pipeline
+    ///   of WP-303, this layout would typically be empty (created with no descriptor set layouts
+    ///   and no push constant ranges via `create_vulkan_pipeline_layout`).
+    ///
+    /// # Returns
+    /// A `Result` containing the new `VulkanPipeline` instance, or an error string if pipeline creation fails.
+    ///
+    /// # `Rendering Vulkan.md` Specification Mapping (Spec 6.4):
+    /// - **6.4.1 (Shader Stages):** Configured with provided vertex and fragment shader modules.
+    /// - **6.4.2 (Vertex Input):** Configured with provided binding and attribute descriptions.
+    /// - **6.4.3 (Input Assembly):** `TRIANGLE_LIST` topology.
+    /// - **6.4.4 (Viewport/Scissor):** Configured for dynamic state.
+    /// - **6.4.5 (Rasterization):** Basic fill mode, culling typically BACK (can be NONE for simple cases).
+    /// - **6.4.6 (Multisampling):** Disabled (`SAMPLE_COUNT_1_BIT`).
+    /// - **6.4.7 (Depth/Stencil):** Configurable, typically enabled for 3D. For simple 2D, can be disabled.
+    /// - **6.4.8, 6.4.9 (Color Blending):** Basic opaque blending.
+    /// - **6.4.10 (Dynamic State):** Viewport and Scissor are dynamic.
+    /// - **6.4.11 (Pipeline Create Info):** Assembles all above states with the provided `pipeline_layout` and `render_pass`.
+    pub fn new_with_vertex_input( // Renamed from new_minimal
         device: Arc<AshDevice>,
         render_pass: vk::RenderPass,
-        swapchain_extent: vk::Extent2D,
+        _swapchain_extent: vk::Extent2D,
         vert_shader_module: &VulkanShaderModule,
         frag_shader_module: &VulkanShaderModule,
-        texture_descriptor_set_layout: vk::DescriptorSetLayout, // Added
+        pipeline_layout: vk::PipelineLayout,
+        binding_descriptions: &[vk::VertexInputBindingDescription],    // New parameter
+        attribute_descriptions: &[vk::VertexInputAttributeDescription], // New parameter
     ) -> Result<Self, String> {
 
-        // ANCHOR_EXT: Shader Stages
+        // Shader Stages (Spec 6.4.1)
         let vert_shader_stage_info = vk::PipelineShaderStageCreateInfo::builder()
             .stage(vk::ShaderStageFlags::VERTEX)
             .module(vert_shader_module.handle())
-            .name(std::ffi::CStr::from_bytes_with_nul(b"main\0").unwrap()); // Entry point
+            .name(std::ffi::CStr::from_bytes_with_nul(b"main\0").expect("Failed to create CStr for vertex shader entry point."));
 
         let frag_shader_stage_info = vk::PipelineShaderStageCreateInfo::builder()
             .stage(vk::ShaderStageFlags::FRAGMENT)
             .module(frag_shader_module.handle())
-            .name(std::ffi::CStr::from_bytes_with_nul(b"main\0").unwrap()); // Entry point
+            .name(std::ffi::CStr::from_bytes_with_nul(b"main\0").expect("Failed to create CStr for fragment shader entry point."));
 
         let shader_stages = [vert_shader_stage_info.build(), frag_shader_stage_info.build()];
 
-        // ANCHOR_EXT: Vertex Input State (for textured quad)
-        // vec2 pos, vec2 texcoord
-        const STRIDE: u32 = (2 + 2) * std::mem::size_of::<f32>() as u32;
-
-        let binding_descriptions = [vk::VertexInputBindingDescription::builder()
-            .binding(0)
-            .stride(STRIDE)
-            .input_rate(vk::VertexInputRate::VERTEX)
-            .build()];
-
-        let attribute_descriptions = [
-            // Position (vec2)
-            vk::VertexInputAttributeDescription::builder()
-                .location(0) // layout (location = 0) in shader
-                .binding(0)
-                .format(vk::Format::R32G32_SFLOAT)
-                .offset(0)
-                .build(),
-            // Texture Coordinate (vec2)
-            vk::VertexInputAttributeDescription::builder()
-                .location(1) // layout (location = 1) in shader
-                .binding(0)
-                .format(vk::Format::R32G32_SFLOAT)
-                .offset((2 * std::mem::size_of::<f32>()) as u32) // Offset after position
-                .build(),
-        ];
-
+        // Vertex Input State (Spec 6.4.2) - Now uses parameters
         let vertex_input_info = vk::PipelineVertexInputStateCreateInfo::builder()
-            .vertex_binding_descriptions(&binding_descriptions)
-            .vertex_attribute_descriptions(&attribute_descriptions);
+            .vertex_binding_descriptions(binding_descriptions)
+            .vertex_attribute_descriptions(attribute_descriptions);
 
-        // ANCHOR_EXT: Input Assembly State
+        // Input Assembly State (Spec 6.4.3)
         let input_assembly = vk::PipelineInputAssemblyStateCreateInfo::builder()
-            .topology(vk::PrimitiveTopology::TRIANGLE_LIST)
+            .topology(vk::PrimitiveTopology::TRIANGLE_LIST) // Standard for drawing triangles
             .primitive_restart_enable(false);
 
-        // ANCHOR_EXT: Viewport and Scissor
-        let viewport = vk::Viewport::builder()
-            .x(0.0)
-            .y(0.0)
-            .width(swapchain_extent.width as f32)
-            .height(swapchain_extent.height as f32)
-            .min_depth(0.0)
-            .max_depth(1.0)
-            .build();
-
-        let scissor = vk::Rect2D::builder()
-            .offset(vk::Offset2D { x: 0, y: 0 })
-            .extent(swapchain_extent)
-            .build();
-
-        // ANCHOR_EXT: Viewport State
-        // If not using dynamic viewport/scissor, this is how you set them:
-        // let viewport_state = vk::PipelineViewportStateCreateInfo::builder()
-        //     .viewports(std::slice::from_ref(&viewport))
-        //     .scissors(std::slice::from_ref(&scissor));
-        // However, we'll use dynamic states for viewport and scissor for more flexibility.
+        // Viewport State (Spec 6.4.4) - Using dynamic viewport and scissor
         let viewport_state = vk::PipelineViewportStateCreateInfo::builder()
-            .viewport_count(1) // Dynamic state will provide actual viewport
-            .scissor_count(1); // Dynamic state will provide actual scissor
+            .viewport_count(1) // Will be set dynamically
+            .scissor_count(1);  // Will be set dynamically
 
-
-        // ANCHOR_EXT: Rasterization State
+        // Rasterization State (Spec 6.4.5)
         let rasterizer = vk::PipelineRasterizationStateCreateInfo::builder()
             .depth_clamp_enable(false)
-            .rasterizer_discard_enable(false)
+            .rasterizer_discard_enable(false) // We want to rasterize
             .polygon_mode(vk::PolygonMode::FILL)
             .line_width(1.0)
-            .cull_mode(vk::CullModeFlags::BACK)
-            .front_face(vk::FrontFace::CLOCKWISE) // Assuming standard winding order
-            .depth_bias_enable(false);
+            .cull_mode(vk::CullModeFlags::NONE) // No culling for a simple clear/triangle
+            .front_face(vk::FrontFace::CLOCKWISE); // Or COUNTER_CLOCKWISE, depends on triangle winding
 
-        // ANCHOR_EXT: Multisample State
+        // Multisample State (Spec 6.4.6)
         let multisampling = vk::PipelineMultisampleStateCreateInfo::builder()
             .sample_shading_enable(false)
-            .rasterization_samples(vk::SampleCountFlags::TYPE_1);
-            // .min_sample_shading(1.0) // Optional
-            // .sample_mask(&[]) // Optional
-            // .alpha_to_coverage_enable(false) // Optional
-            // .alpha_to_one_enable(false); // Optional
+            .rasterization_samples(vk::SampleCountFlags::TYPE_1); // No MSAA
 
-        // ANCHOR_EXT: Depth/Stencil State (Disabled for now)
+        // Depth/Stencil State (Spec 6.4.7) - Disabled for simple 2D clear/triangle
         let depth_stencil_state = vk::PipelineDepthStencilStateCreateInfo::builder()
             .depth_test_enable(false)
             .depth_write_enable(false)
-            .depth_compare_op(vk::CompareOp::LESS_OR_EQUAL) // Common default
+            .depth_compare_op(vk::CompareOp::LESS_OR_EQUAL)
             .depth_bounds_test_enable(false)
             .stencil_test_enable(false);
-            // .min_depth_bounds(0.0) // Optional
-            // .max_depth_bounds(1.0); // Optional
 
-        // ANCHOR_EXT: Color Blend Attachment State (Opaque for now)
+        // Color Blend Attachment State (Spec 6.4.8)
         let color_blend_attachment = vk::PipelineColorBlendAttachmentState::builder()
-            .color_write_mask(vk::ColorComponentFlags::RGBA)
-            .blend_enable(false) // No blending
-            // Example for alpha blending (if blend_enable(true)):
-            // .src_color_blend_factor(vk::BlendFactor::SRC_ALPHA)
-            // .dst_color_blend_factor(vk::BlendFactor::ONE_MINUS_SRC_ALPHA)
-            // .color_blend_op(vk::BlendOp::ADD)
-            // .src_alpha_blend_factor(vk::BlendFactor::ONE)
-            // .dst_alpha_blend_factor(vk::BlendFactor::ZERO)
-            // .alpha_blend_op(vk::BlendOp::ADD)
+            .color_write_mask(vk::ColorComponentFlags::RGBA) // Write to all color channels
+            .blend_enable(false) // No blending for simple clear/triangle
             .build();
 
-        // ANCHOR_EXT: Color Blend State
+        // Color Blend State (Spec 6.4.9)
         let color_blending = vk::PipelineColorBlendStateCreateInfo::builder()
-            .logic_op_enable(false)
-            .logic_op(vk::LogicOp::COPY) // Optional
-            .attachments(std::slice::from_ref(&color_blend_attachment))
-            .blend_constants([0.0, 0.0, 0.0, 0.0]); // Optional
+            .logic_op_enable(false) // No logical operations
+            .attachments(std::slice::from_ref(&color_blend_attachment));
 
-        // ANCHOR_EXT: Pipeline Layout
-        let set_layouts = [texture_descriptor_set_layout];
-        let pipeline_layout_create_info = vk::PipelineLayoutCreateInfo::builder()
-            .set_layouts(&set_layouts) // Use the passed-in descriptor set layout
-            .push_constant_ranges(&[]); // No push constants yet
-
-        let pipeline_layout = unsafe {
-            device.create_pipeline_layout(&pipeline_layout_create_info, None)
-        }.map_err(|e| format!("Failed to create pipeline layout: {}", e))?;
-
-        // ANCHOR_EXT: Dynamic States
+        // Dynamic States (Spec 6.4.10)
         let dynamic_states = [vk::DynamicState::VIEWPORT, vk::DynamicState::SCISSOR];
         let dynamic_state_info = vk::PipelineDynamicStateCreateInfo::builder()
             .dynamic_states(&dynamic_states);
 
-        // ANCHOR_EXT: Graphics Pipeline Create Info
-        let pipeline_info = vk::GraphicsPipelineCreateInfo::builder()
+        // Graphics Pipeline Create Info (Spec 6.4.11)
+        let pipeline_info_builder = vk::GraphicsPipelineCreateInfo::builder()
             .stages(&shader_stages)
             .vertex_input_state(&vertex_input_info)
             .input_assembly_state(&input_assembly)
-            .viewport_state(&viewport_state) // Viewport and scissor set via dynamic states
+            .viewport_state(&viewport_state)
             .rasterization_state(&rasterizer)
             .multisample_state(&multisampling)
-            .depth_stencil_state(&depth_stencil_state) // Or None if completely disabled
+            .depth_stencil_state(&depth_stencil_state)
             .color_blend_state(&color_blending)
-            .dynamic_state(&dynamic_state_info) // Specify dynamic states
-            .layout(pipeline_layout)
+            .dynamic_state(&dynamic_state_info)
+            .layout(pipeline_layout) // Use the pre-created layout
             .render_pass(render_pass)
-            .subpass(0) // Index of the subpass where this pipeline will be used
-            .base_pipeline_handle(vk::Pipeline::null()) // Optional: for pipeline derivatives
-            .base_pipeline_index(-1); // Optional
+            .subpass(0); // Index of the subpass
+
+        let pipeline_create_info = pipeline_info_builder.build();
 
         let pipelines = unsafe {
-            device.create_graphics_pipelines(vk::PipelineCache::null(), std::slice::from_ref(&pipeline_info.build()), None)
-        }.map_err(|e| {
-            // Cleanup pipeline layout if pipeline creation fails
-            unsafe { device.destroy_pipeline_layout(pipeline_layout, None); }
-            format!("Failed to create graphics pipeline: {:?}", e) // Using {:?} for result type
+            device.create_graphics_pipelines(vk::PipelineCache::null(), &[pipeline_create_info], None)
+        }.map_err(|(_pipelines, result)| { // create_graphics_pipelines returns Result<Vec<Pipeline>, (Vec<Pipeline>, Result)>
+            // Note: The pipeline_layout is owned by the caller of new_minimal, so we don't destroy it here.
+            format!("Failed to create graphics pipeline: {:?}", result)
         })?;
 
-        let pipeline = pipelines[0]; // We only create one pipeline
+        if pipelines.is_empty() {
+             // This case should ideally be caught by the map_err above, but as a safeguard:
+            return Err("Graphics pipeline creation returned an empty vector, but no error code.".to_string());
+        }
+        let pipeline = pipelines[0]; // We expect one pipeline
 
         Ok(Self {
             device,

--- a/novade-system/src/renderers/vulkan/render_pass.rs
+++ b/novade-system/src/renderers/vulkan/render_pass.rs
@@ -7,62 +7,127 @@ pub struct VulkanRenderPass {
     render_pass: vk::RenderPass,
 }
 
+/// Creates a simple Vulkan Render Pass suitable for basic rendering operations.
+///
+/// This render pass is configured with a single color attachment. It defines how the
+/// attachment is handled at the beginning (load operation: clear) and end (store operation: store)
+/// of the pass, as well as its layout transitions. The final layout is set to
+/// `PRESENT_SRC_KHR`, making it suitable for images that will be presented to a swapchain.
+///
+/// This implementation directly follows the requirements outlined in
+/// `Rendering Vulkan.md` (Spec 6.3 - Render-Pass-Definition).
+///
+/// # Arguments
+/// * `device`: A reference to the logical `ash::Device`.
+/// * `color_format`: The `vk::Format` of the color attachment. This should typically match
+///   the format of the swapchain images.
+///
+/// # Returns
+/// A `Result` containing the created `vk::RenderPass` handle, or an error string
+/// if creation fails.
+///
+/// # `Rendering Vulkan.md` Specification Mapping (Spec 6.3):
+/// - **`VkAttachmentDescription`**:
+///   - `format`: Matches `color_format` parameter.
+///   - `samples`: `VK_SAMPLE_COUNT_1_BIT` (no multisampling).
+///   - `loadOp`: `VK_ATTACHMENT_LOAD_OP_CLEAR` (to clear the screen).
+///   - `storeOp`: `VK_ATTACHMENT_STORE_OP_STORE` (to store the result for presentation).
+///   - `stencilLoadOp`/`stencilStoreOp`: `VK_ATTACHMENT_LOAD_OP_DONT_CARE` (no stencil).
+///   - `initialLayout`: `VK_IMAGE_LAYOUT_UNDEFINED` (previous content is not needed).
+///   - `finalLayout`: `VK_IMAGE_LAYOUT_PRESENT_SRC_KHR` (for swapchain presentation).
+/// - **`VkAttachmentReference`**:
+///   - `attachment`: 0 (references the single color attachment).
+///   - `layout`: `VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL` (optimal for rendering).
+/// - **`VkSubpassDescription`**:
+///   - `pipelineBindPoint`: `VK_PIPELINE_BIND_POINT_GRAPHICS`.
+///   - `colorAttachments`: Points to the color attachment reference.
+/// - **`VkSubpassDependency`**: A basic dependency is set up to handle layout transitions
+///   from an external source to the color attachment write state.
+pub fn create_vulkan_render_pass(
+    device: &AshDevice,
+    color_format: vk::Format,
+/// This render pass is configured with a single color attachment, suitable for
+/// clearing the screen and presenting to a swapchain. It defines load operations,
+/// store operations, and layout transitions for the attachment.
+/// Aligns with `Rendering Vulkan.md` (Spec 6.3).
+///
+/// # Arguments
+/// * `device`: A reference to the logical `ash::Device`.
+/// * `color_format`: The `vk::Format` of the color attachment (typically the swapchain image format).
+///
+/// # Returns
+/// A `Result` containing the created `vk::RenderPass` or an error string on failure.
+pub fn create_vulkan_render_pass(
+    device: &AshDevice,
+    color_format: vk::Format,
+) -> Result<vk::RenderPass, String> {
+    // Attachment Description (Spec 6.3)
+    // Describes the properties of the color attachment.
+    let color_attachment = vk::AttachmentDescription::builder()
+        .format(color_format) // Format of the swapchain images
+        .samples(vk::SampleCountFlags::TYPE_1) // No multisampling
+        .load_op(vk::AttachmentLoadOp::CLEAR) // Clear the attachment at the beginning of the pass
+        .store_op(vk::AttachmentStoreOp::STORE) // Store the rendered content for presentation
+        .stencil_load_op(vk::AttachmentLoadOp::DONT_CARE) // No stencil buffer
+        .stencil_store_op(vk::AttachmentStoreOp::DONT_CARE) // No stencil buffer
+        .initial_layout(vk::ImageLayout::UNDEFINED) // We don't care about the previous content
+        .final_layout(vk::ImageLayout::PRESENT_SRC_KHR); // Transition to present layout after the pass
+
+    // Attachment Reference (Spec 6.3)
+    // Specifies which attachment to use for the subpass and its layout during the subpass.
+    let color_attachment_ref = vk::AttachmentReference::builder()
+        .attachment(0) // Index of the attachment in the `attachments` array
+        .layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL); // Layout optimal for color rendering
+
+    // Subpass Description (Spec 6.3)
+    // Defines a single subpass that uses the color attachment.
+    let subpass = vk::SubpassDescription::builder()
+        .pipeline_bind_point(vk::PipelineBindPoint::GRAPHICS) // Graphics pipeline
+        .color_attachments(std::slice::from_ref(&color_attachment_ref));
+
+    // Subpass Dependency (Spec 6.3, though details may vary)
+    // Ensures proper synchronization between operations outside and inside the render pass.
+    // This dependency handles the transition from an external state (e.g., swapchain image acquired)
+    // to the state where the color attachment can be written to.
+    let dependency = vk::SubpassDependency::builder()
+        .src_subpass(vk::SUBPASS_EXTERNAL) // Implicit subpass before this render pass
+        .dst_subpass(0) // Index of our subpass
+        .src_stage_mask(vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT) // Stage where previous writes to image might have occurred (or semaphore signal)
+        .src_access_mask(vk::AccessFlags::empty()) // No specific access from src needed if initialLayout is UNDEFINED and loadOp is CLEAR
+        .dst_stage_mask(vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT) // Stage where our subpass writes
+        .dst_access_mask(vk::AccessFlags::COLOR_ATTACHMENT_WRITE); // Access type for our subpass
+
+    // Render Pass Create Info (Spec 6.3)
+    // Combines attachments, subpasses, and dependencies to define the render pass.
+    let render_pass_create_info = vk::RenderPassCreateInfo::builder()
+        .attachments(std::slice::from_ref(&color_attachment))
+        .subpasses(std::slice::from_ref(&subpass))
+        .dependencies(std::slice::from_ref(&dependency));
+
+    unsafe {
+        device
+            .create_render_pass(&render_pass_create_info, None)
+            .map_err(|e| format!("Failed to create render pass: {}", e))
+    }
+}
+
+
 // ANCHOR: VulkanRenderPass Implementation
 impl VulkanRenderPass {
+    /// Creates a new `VulkanRenderPass` instance.
+    ///
+    /// This constructor wraps the `create_vulkan_render_pass` free function.
+    ///
+    /// # Arguments
+    /// * `device`: An `Arc` reference to the logical `ash::Device`.
+    /// * `color_format`: The `vk::Format` of the color attachment.
+    ///
+    /// # Returns
+    /// A `Result` containing the new `VulkanRenderPass` or an error string.
     pub fn new(device: Arc<AshDevice>, color_format: vk::Format) -> Result<Self, String> {
-        // ANCHOR_EXT: Attachment Description
-        let color_attachment = vk::AttachmentDescription::builder()
-            .format(color_format)
-            .samples(vk::SampleCountFlags::TYPE_1)
-            .load_op(vk::AttachmentLoadOp::CLEAR)
-            .store_op(vk::AttachmentStoreOp::STORE)
-            .stencil_load_op(vk::AttachmentLoadOp::DONT_CARE)
-            .stencil_store_op(vk::AttachmentStoreOp::DONT_CARE)
-            .initial_layout(vk::ImageLayout::UNDEFINED)
-            .final_layout(vk::ImageLayout::PRESENT_SRC_KHR) // For direct presentation
-            .build();
-
-        // ANCHOR_EXT: Color Attachment Reference
-        let color_attachment_ref = vk::AttachmentReference::builder()
-            .attachment(0) // Index in the pAttachments array of RenderPassCreateInfo
-            .layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
-            .build();
-
-        // ANCHOR_EXT: Subpass Description
-        let subpass = vk::SubpassDescription::builder()
-            .pipeline_bind_point(vk::PipelineBindPoint::GRAPHICS)
-            .color_attachments(std::slice::from_ref(&color_attachment_ref))
-            // No depth/stencil, input, resolve, or preserve attachments for this simple pass
-            .build();
-
-        // ANCHOR_EXT: Subpass Dependency
-        // This dependency ensures that the render pass waits for the image to be available
-        // (e.g., from the swapchain) before writing to it, and that writing is finished
-        // before the image is presented.
-        let dependency = vk::SubpassDependency::builder()
-            .src_subpass(vk::SUBPASS_EXTERNAL) // Implicit subpass before render pass
-            .dst_subpass(0) // Our subpass (index 0)
-            .src_stage_mask(vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT)
-            .src_access_mask(vk::AccessFlags::empty()) // No access required from previous stage for this simple case
-            .dst_stage_mask(vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT)
-            .dst_access_mask(vk::AccessFlags::COLOR_ATTACHMENT_WRITE)
-            .build();
-
-        // ANCHOR_EXT: Render Pass Create Info
-        let render_pass_create_info = vk::RenderPassCreateInfo::builder()
-            .attachments(std::slice::from_ref(&color_attachment))
-            .subpasses(std::slice::from_ref(&subpass))
-            .dependencies(std::slice::from_ref(&dependency))
-            .build();
-
-        let render_pass = unsafe {
-            device
-                .create_render_pass(&render_pass_create_info, None)
-                .map_err(|e| format!("Failed to create render pass: {}", e))?
-        };
-
-        println!("VulkanRenderPass created successfully.");
-        Ok(Self { device, render_pass })
+        let render_pass_handle = create_vulkan_render_pass(device.as_ref(), color_format)?;
+        println!("VulkanRenderPass created successfully (via new method wrapping free function).");
+        Ok(Self { device, render_pass: render_pass_handle })
     }
 
     // ANCHOR: Accessor for vk::RenderPass

--- a/novade-system/src/renderers/vulkan/surface.rs
+++ b/novade-system/src/renderers/vulkan/surface.rs
@@ -1,8 +1,29 @@
 // novade-system/src/renderers/vulkan/surface.rs
-use ash::extensions::khr::Surface as SurfaceLoader; // Alias to avoid conflict
+// use ash::extensions::khr::Surface as SurfaceLoader; // Not directly used, ash_window handles it.
 use ash::vk;
 use raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle};
 
+/// Creates a Vulkan surface (`vk::SurfaceKHR`) for rendering.
+///
+/// This function uses `ash_window::create_surface` to abstract the platform-specific
+/// surface creation details. It relies on the `raw-window-handle` traits
+/// (`HasRawDisplayHandle`, `HasRawWindowHandle`) to obtain the necessary native
+/// display and window handles (e.g., `wl_display` and `wl_surface` for Wayland)
+/// from the provided providers.
+///
+/// This aligns with `Rendering Vulkan.md` (Spec 5.1) for Wayland surface creation.
+///
+/// # Arguments
+/// * `entry`: A reference to the loaded `ash::Entry` point.
+/// * `instance`: A reference to the `ash::Instance`.
+/// * `raw_display_handle_provider`: A provider that implements `HasRawDisplayHandle`
+///   (e.g., a Smithay Wayland compositor object for `wl_display`).
+/// * `raw_window_handle_provider`: A provider that implements `HasRawWindowHandle`
+///   (e.g., a Smithay Wayland surface object for `wl_surface`).
+///
+/// # Returns
+/// A `Result` containing the created `vk::SurfaceKHR` handle, or an error string
+/// if surface creation fails.
 pub fn create_surface(
     entry: &ash::Entry,
     instance: &ash::Instance,
@@ -15,7 +36,7 @@ pub fn create_surface(
             instance,
             raw_display_handle_provider.raw_display_handle(),
             raw_window_handle_provider.raw_window_handle(),
-            None,
+            None, // Allocator callbacks, not used here
         )
         .map_err(|e| format!("Failed to create Vulkan surface: {}", e))
     }

--- a/novade-system/src/renderers/vulkan/swapchain.rs
+++ b/novade-system/src/renderers/vulkan/swapchain.rs
@@ -35,56 +35,452 @@ pub struct VulkanSwapchain {
     instance_ref: Arc<AshInstance>, // Keep a reference to instance for surface cleanup
 }
 
+/// Helper function to create `vk::ImageView`s for a set of swapchain `vk::Image`s.
+///
+/// Each image view will be a 2D view of the color aspect of the corresponding image.
+///
+/// # Arguments
+/// * `device`: Reference to the logical `ash::Device`.
+/// * `images`: Slice of `vk::Image` handles (typically from the swapchain).
+/// * `format`: The `vk::Format` of the images.
+///
+/// # Returns
+/// A `Result` containing a `Vec<vk::ImageView>` or an error string on failure.
+fn create_swapchain_image_views(
+    device: &AshDevice,
+    images: &[vk::Image],
+    format: vk::Format,
+) -> Result<Vec<vk::ImageView>, String> {
+    images
+        .iter()
+        .map(|&image| {
+            let create_info = vk::ImageViewCreateInfo::builder()
+                .image(image)
+                .view_type(vk::ImageViewType::TYPE_2D)
+                .format(format)
+                .components(vk::ComponentMapping {
+                    r: vk::ComponentSwizzle::IDENTITY,
+                    g: vk::ComponentSwizzle::IDENTITY,
+                    b: vk::ComponentSwizzle::IDENTITY,
+                    a: vk::ComponentSwizzle::IDENTITY,
+                })
+                .subresource_range(vk::ImageSubresourceRange {
+                    aspect_mask: vk::ImageAspectFlags::COLOR,
+                    base_mip_level: 0,
+                    level_count: 1,
+                    base_array_layer: 0,
+                    layer_count: 1,
+                });
+            unsafe {
+                device.create_image_view(&create_info, None)
+            }.map_err(|e| format!("Failed to create image view: {}", e))
+        })
+        .collect()
+}
+
+
 // ANCHOR: VulkanSwapchain Implementation
 impl VulkanSwapchain {
+    /// Creates a new `VulkanSwapchain` instance.
+    ///
+    /// This constructor handles the creation of a Vulkan surface, queries for swapchain support,
+    /// chooses appropriate settings (format, present mode, extent), and then creates the
+    /// swapchain, its images, and image views. It uses the `create_swapchain_direct`
+    /// function internally for the core swapchain creation logic.
+    ///
+    /// # Arguments
+    /// * `context`: A reference to `VulkanContext` which provides necessary Vulkan handles
+    ///   (instance, device, physical device, entry point, queue indices).
+    /// * `window_handle`: A provider for `RawWindowHandle`, used to create the Vulkan surface.
+    /// * `window_width`: The initial width for the swapchain extent.
+    /// * `window_height`: The initial height for the swapchain extent.
+    /// * `old_swapchain_khr`: An optional `vk::SwapchainKHR` handle if this is a recreation
+    ///   (e.g., after a window resize).
+    ///
+    /// # Returns
+    /// A `Result` containing the new `VulkanSwapchain` or an error string on failure.
     pub fn new(
         context: &VulkanContext, // Provides instance, device, physical_device, entry
-        window_handle: &impl HasRawWindowHandle,
+        window_handle: &impl HasRawWindowHandle, // Used for surface creation internally
         window_width: u32,
         window_height: u32,
-        old_swapchain_khr: Option<vk::SwapchainKHR>,
+        old_swapchain_khr: Option<vk::SwapchainKHR>, // For recreation
     ) -> Result<Self, String> {
 
-        // ANCHOR_EXT: Surface Creation
+        // Surface creation is part of this constructor for VulkanSwapchain convenience
         let surface_loader = ash::extensions::khr::Surface::new(context.entry(), context.instance());
         let surface = unsafe {
             ash_window::create_surface(
                 context.entry(),
                 context.instance(),
-                window_handle.raw_window_handle(),
-                None,
+                // context.raw_display_handle(), // Assuming context provides this
+                window_handle.raw_window_handle(), // The prompt implies this is how it's passed
+                None, // Allocator
             )
-        }.map_err(|e| format!("Failed to create Vulkan surface: {}", e))?;
+        }.map_err(|e| format!("VulkanSwapchain::new: Failed to create Vulkan surface: {}", e))?;
 
-        // Check for Wayland surface support on the physical device's queue family
-        // This check was simplified in context.rs, but should be more robust here or in context.
-        // For now, assume the queue family selected in VulkanContext supports presentation to this surface.
+        // Ensure the selected physical device's queue family supports this surface
+        // This check is crucial and relies on VulkanContext providing correct queue indices.
         let present_support = unsafe {
             surface_loader.get_physical_device_surface_support(
                 context.physical_device(),
-                context.present_queue_family_index(), // Assuming present_queue_family_index is correct for this surface
+                context.present_queue_family_index(),
                 surface,
             )
         }.unwrap_or(false);
 
         if !present_support {
-            // Cleanup surface before erroring
-            unsafe { surface_loader.destroy_surface(surface, None); }
+            unsafe { surface_loader.destroy_surface(surface, None); } // Clean up created surface
             return Err(format!(
-                "Physical device queue family {} does not support presentation to this surface.",
+                "VulkanSwapchain::new: Physical device queue family {} does not support presentation to the created surface.",
                 context.present_queue_family_index()
             ));
         }
 
-        // ANCHOR_EXT: Query Swapchain Support
-        let support_details = Self::query_swapchain_support(
-            context.instance(),
-            &surface_loader,
-            context.physical_device(),
-            surface,
-        )?;
+        let (swapchain_loader_new, swapchain, format, extent, images, image_views) =
+            create_swapchain_direct(
+                context.instance(),
+                context.device().as_ref(), // Get &AshDevice from Arc<AshDevice>
+                context.physical_device(),
+                &surface_loader, // Pass the loader created above
+                surface, // Pass the surface created above
+                context.graphics_queue_family_index(), // Assuming these are correct from context
+                context.present_queue_family_index(),
+                window_width,
+                window_height,
+                old_swapchain_khr,
+            ).map_err(|e| {
+                // If create_swapchain_direct fails, the surface it was given still needs cleanup here
+                unsafe { surface_loader.destroy_surface(surface, None); }
+                e
+            })?;
 
-        // ANCHOR_EXT: Choose Swapchain Settings
+        Ok(Self {
+            surface_loader, // Store the loader used for the surface
+            swapchain_loader: swapchain_loader_new,
+            surface, // Store the surface
+            swapchain,
+            images,
+            image_views,
+            format,
+            extent,
+            device: context.device().clone(),
+            instance_ref: context.instance_arc(),
+        })
+    }
+
+    // ANCHOR: Accessors
+    /// Returns the `vk::Format` of the swapchain images.
+    pub fn format(&self) -> vk::Format {
+        self.format
+    }
+
+    /// Returns the `vk::Extent2D` (dimensions) of the swapchain images.
+    pub fn extent(&self) -> vk::Extent2D {
+        self.extent
+    }
+
+    /// Returns a slice of `vk::ImageView`s for the swapchain images.
+    pub fn image_views(&self) -> &Vec<vk::ImageView> {
+        &self.image_views
+    }
+
+    // ANCHOR: Query Swapchain Support Helper
+    /// Queries the physical device for its swapchain support capabilities for a given surface.
+    ///
+    /// This includes surface capabilities (min/max image count, extents, etc.),
+    /// supported surface formats, and available presentation modes.
+    /// Aligns with `Rendering Vulkan.md` (Spec 5.2.1, 5.2.2, 5.2.3).
+    /// This is a public static method to be usable by `create_swapchain_direct`.
+    ///
+    /// # Arguments
+    /// * `instance_ash`: Reference to the `ash::Instance`.
+    /// * `surface_loader`: Reference to the `ash::extensions::khr::Surface` loader.
+    /// * `physical_device`: The `vk::PhysicalDevice` to query.
+    /// * `surface`: The `vk::SurfaceKHR` to query support for.
+    ///
+    /// # Returns
+    /// A `Result` containing `SwapchainSupportDetails` or an error string.
+    pub fn query_swapchain_support(
+        instance_ash: &AshInstance,
+        surface_loader: &ash::extensions::khr::Surface,
+        physical_device: vk::PhysicalDevice,
+        surface: vk::SurfaceKHR,
+    ) -> Result<SwapchainSupportDetails, String> {
+        unsafe {
+            let capabilities = surface_loader
+                .get_physical_device_surface_capabilities(physical_device, surface)
+                .map_err(|e| format!("Failed to get surface capabilities: {}", e))?;
+
+            let formats = surface_loader
+                .get_physical_device_surface_formats(physical_device, surface)
+                .map_err(|e| format!("Failed to get surface formats: {}", e))?;
+
+            let present_modes = surface_loader
+                .get_physical_device_surface_present_modes(physical_device, surface)
+                .map_err(|e| format!("Failed to get surface present modes: {}", e))?;
+
+            if formats.is_empty() || present_modes.is_empty() {
+                return Err("No surface formats or present modes found for the physical device and surface.".to_string());
+            }
+
+            Ok(SwapchainSupportDetails {
+                capabilities,
+                formats,
+                present_modes,
+            })
+        }
+    }
+
+    // ANCHOR: Choose Surface Format Helper
+    /// Selects a suitable `vk::SurfaceFormatKHR` from the list of available formats.
+    ///
+    /// Prioritizes `VK_FORMAT_B8G8R8A8_SRGB` with `VK_COLOR_SPACE_SRGB_NONLINEAR_KHR`
+    /// as per `Rendering Vulkan.md` (Spec 5.2.2). Falls back to the first available format if not found.
+    /// This is a public static method.
+    pub fn choose_surface_format(
+        available_formats: &[vk::SurfaceFormatKHR],
+    ) -> vk::SurfaceFormatKHR {
+        available_formats
+            .iter()
+            .find(|format| {
+                format.format == vk::Format::B8G8R8A8_SRGB
+                    && format.color_space == vk::ColorSpaceKHR::SRGB_NONLINEAR
+            })
+            .cloned()
+            .unwrap_or_else(|| {
+                eprintln!("Warning: Desired format B8G8R8A8_SRGB with SRGB_NONLINEAR not found. Using first available: {:?}", available_formats[0]);
+                available_formats[0]
+            })
+    }
+
+    // ANCHOR: Choose Present Mode Helper
+    /// Selects a `vk::PresentModeKHR` from the list of available modes.
+    ///
+    /// Prioritizes `MAILBOX` for low latency, then `FIFO_RELAXED`, then `FIFO` (guaranteed).
+    /// Aligns with `Rendering Vulkan.md` (Spec 5.2.3).
+    /// This is a public static method.
+    pub fn choose_present_mode(
+        available_present_modes: &[vk::PresentModeKHR],
+    ) -> vk::PresentModeKHR {
+        // Spec 5.2.3: Prioritize MAILBOX for low latency, then FIFO_RELAXED, then FIFO.
+        if available_present_modes.contains(&vk::PresentModeKHR::MAILBOX) {
+            vk::PresentModeKHR::MAILBOX
+        } else if available_present_modes.contains(&vk::PresentModeKHR::FIFO_RELAXED) {
+            vk::PresentModeKHR::FIFO_RELAXED
+        } else {
+            vk::PresentModeKHR::FIFO // Guaranteed available
+        }
+    }
+
+    // ANCHOR: Choose Swap Extent Helper
+    /// Determines the `vk::Extent2D` (resolution) for the swapchain images.
+    ///
+    /// Uses the surface capabilities' `currentExtent` if defined, otherwise clamps
+    /// the provided window width/height to the min/max extents supported by the surface.
+    /// Aligns with `Rendering Vulkan.md` (Spec 5.2.4 `imageExtent`).
+    /// This is a public static method.
+    pub fn choose_swap_extent(
+        capabilities: &vk::SurfaceCapabilitiesKHR,
+        window_width: u32,
+        window_height: u32,
+    ) -> vk::Extent2D {
+        if capabilities.current_extent.width != u32::MAX {
+            capabilities.current_extent
+        } else {
+            vk::Extent2D {
+                width: window_width.clamp(
+                    capabilities.min_image_extent.width,
+                    capabilities.max_image_extent.width,
+                ),
+                height: window_height.clamp(
+                    capabilities.min_image_extent.height,
+                    capabilities.max_image_extent.height,
+                ),
+            }
+        }
+    }
+
+    // ANCHOR: Create Image Views Helper (moved to top-level)
+    // fn create_image_views(...) - now a top-level function: create_swapchain_image_views
+}
+
+
+/// Creates a Vulkan swapchain and its associated resources directly.
+///
+/// This function encapsulates the logic for swapchain creation as per `Rendering Vulkan.md` (Spec 5.2).
+/// It handles querying surface capabilities, choosing appropriate formats, present modes, and extents,
+/// creating the `vk::SwapchainKHR` object, retrieving its images, and creating `vk::ImageView`s for them.
+/// This is a procedural approach to setting up the swapchain components.
+///
+/// # Arguments
+/// * `instance`: A reference to the `ash::Instance`.
+/// * `device`: A reference to the logical `ash::Device`.
+/// * `physical_device`: The `vk::PhysicalDevice` being used.
+/// * `surface_loader`: A reference to the `ash::extensions::khr::Surface` loader.
+/// * `surface`: The `vk::SurfaceKHR` for which the swapchain is created.
+/// * `graphics_q_idx`: The queue family index for graphics operations.
+/// * `present_q_idx`: The queue family index for presentation operations. These indices are used
+///   to configure image sharing modes if they are different.
+/// * `window_width`: The current width of the window/surface, used for determining swapchain extent.
+/// * `window_height`: The current height of the window/surface.
+/// * `old_swapchain`: An `Option<vk::SwapchainKHR>` representing a previous swapchain. This is used
+///   when recreating the swapchain (e.g., after a window resize) to potentially reuse resources
+///   or ensure smoother transitions. Pass `None` for initial creation.
+///
+/// # Returns
+/// A `Result` containing a tuple with the following elements upon success:
+///   - `ash::extensions::khr::Swapchain`: The loader for swapchain functions.
+///   - `vk::SwapchainKHR`: The handle to the created swapchain.
+///   - `vk::Format`: The image format chosen for the swapchain.
+///   - `vk::Extent2D`: The extent (resolution) of the swapchain images.
+///   - `Vec<vk::Image>`: A vector of `vk::Image` handles belonging to the swapchain.
+///   - `Vec<vk::ImageView>`: A vector of `vk::ImageView` handles, one for each swapchain image.
+/// Returns an error string on failure at any step of the process.
+///
+/// # `Rendering Vulkan.md` Specification Mapping (Spec 5.2):
+/// - **5.2.1 (Oberflächen-Fähigkeiten abfragen):** Done via `VulkanSwapchain::query_swapchain_support`.
+/// - **5.2.2 (Oberflächen-Formate abfragen):** Done via `VulkanSwapchain::query_swapchain_support` and chosen by `VulkanSwapchain::choose_surface_format`.
+/// - **5.2.3 (Präsentationsmodi abfragen):** Done via `VulkanSwapchain::query_swapchain_support` and chosen by `VulkanSwapchain::choose_present_mode`.
+/// - **5.2.4 (`VkSwapchainCreateInfoKHR` Konfiguration):** All fields are configured:
+///   - `surface`, `minImageCount`, `imageFormat`, `imageColorSpace`, `imageExtent`, `imageArrayLayers` (1).
+///   - `imageUsage`: Set to `COLOR_ATTACHMENT | TRANSFER_DST` as per spec.
+///   - `imageSharingMode`: Handles `CONCURRENT` vs `EXCLUSIVE` based on queue indices.
+///   - `preTransform`, `compositeAlpha`, `presentMode`, `clipped`, `oldSwapchain`.
+/// - **5.2.5 (`vkCreateSwapchainKHR` Aufruf):** Done via `swapchain_loader.create_swapchain`.
+/// - **5.2.6 (Swapchain-Images abrufen):** Done via `swapchain_loader.get_swapchain_images`.
+/// - Image view creation (related to Spec 6.5 but done here for swapchain images) is handled by `create_swapchain_image_views`.
+#[allow(clippy::too_many_arguments)] // Justified by the number of Vulkan objects needed
+pub fn create_swapchain_direct(
+    instance: &AshInstance,
+/// This function encapsulates the logic for swapchain creation as per `Rendering Vulkan.md` Spec 5.2.
+/// It's a procedural way to get all necessary swapchain components.
+///
+/// # Arguments
+/// * `instance`: The Vulkan instance.
+/// * `device`: The logical device.
+/// * `physical_device`: The physical device.
+/// * `surface_loader`: Loader for surface-related functions.
+/// * `surface`: The `vk::SurfaceKHR` to create the swapchain for.
+/// * `graphics_q_idx`: Index of the graphics queue family.
+/// * `present_q_idx`: Index of the presentation queue family.
+/// * `window_width`: Current width of the window.
+/// * `window_height`: Current height of the window.
+/// * `old_swapchain`: Optional handle to an old swapchain for recreation.
+///
+/// # Returns
+/// A tuple containing:
+///   - `ash::extensions::khr::Swapchain` (the loader for swapchain functions)
+///   - `vk::SwapchainKHR` (the swapchain handle)
+///   - `vk::Format` (the chosen swapchain image format)
+///   - `vk::Extent2D` (the chosen swapchain extent/resolution)
+///   - `Vec<vk::Image>` (the swapchain images)
+///   - `Vec<vk::ImageView>` (image views for the swapchain images)
+#[allow(clippy::too_many_arguments)] // Justified by the number of Vulkan objects needed
+pub fn create_swapchain_direct(
+    instance: &AshInstance,
+    device: &AshDevice,
+    physical_device: vk::PhysicalDevice,
+    surface_loader: &ash::extensions::khr::Surface,
+    surface: vk::SurfaceKHR,
+    graphics_q_idx: u32,
+    present_q_idx: u32,
+    window_width: u32,
+    window_height: u32,
+    old_swapchain: Option<vk::SwapchainKHR>,
+) -> Result<(
+    ash::extensions::khr::Swapchain,
+    vk::SwapchainKHR,
+    vk::Format,
+    vk::Extent2D,
+    Vec<vk::Image>,
+    Vec<vk::ImageView>,
+), String> {
+    let support_details = VulkanSwapchain::query_swapchain_support(
+        instance,
+        surface_loader,
+        physical_device,
+        surface,
+    )?;
+
+    let surface_format = VulkanSwapchain::choose_surface_format(&support_details.formats);
+    let present_mode = VulkanSwapchain::choose_present_mode(&support_details.present_modes);
+    let extent = VulkanSwapchain::choose_swap_extent(&support_details.capabilities, window_width, window_height);
+
+    let mut image_count = support_details.capabilities.min_image_count + 1;
+    if support_details.capabilities.max_image_count > 0 && image_count > support_details.capabilities.max_image_count {
+        image_count = support_details.capabilities.max_image_count;
+    }
+
+    let swapchain_loader = ash::extensions::khr::Swapchain::new(instance, device);
+
+    let mut create_info = vk::SwapchainCreateInfoKHR::builder()
+        .surface(surface)
+        .min_image_count(image_count)
+        .image_format(surface_format.format)
+        .image_color_space(surface_format.color_space)
+        .image_extent(extent)
+        .image_array_layers(1)
+        .image_usage(vk::ImageUsageFlags::COLOR_ATTACHMENT | vk::ImageUsageFlags::TRANSFER_DST); // Spec 5.2.4
+
+    let queue_family_indices_array = [graphics_q_idx, present_q_idx];
+    if graphics_q_idx != present_q_idx {
+        create_info = create_info
+            .image_sharing_mode(vk::SharingMode::CONCURRENT)
+            .queue_family_indices(&queue_family_indices_array);
+    } else {
+        create_info = create_info.image_sharing_mode(vk::SharingMode::EXCLUSIVE);
+    }
+
+    create_info = create_info
+        .pre_transform(support_details.capabilities.current_transform)
+        .composite_alpha(vk::CompositeAlphaFlagsKHR::OPAQUE)
+        .present_mode(present_mode)
+        .clipped(true)
+        .old_swapchain(old_swapchain.unwrap_or_else(vk::SwapchainKHR::null));
+
+    let swapchain_khr = unsafe {
+        swapchain_loader.create_swapchain(&create_info, None)
+    }.map_err(|e| format!("Failed to create swapchain (direct): {}", e))?;
+
+    let images = unsafe {
+        swapchain_loader.get_swapchain_images(swapchain_khr)
+    }.map_err(|e| format!("Failed to get swapchain images (direct): {}", e))?;
+
+    let image_views = create_swapchain_image_views(device, &images, surface_format.format)?;
+
+    Ok((swapchain_loader, swapchain_khr, surface_format.format, extent, images, image_views))
+}
+
+
+// ANCHOR: VulkanSwapchain Drop Implementation
+impl Drop for VulkanSwapchain {
+    fn drop(&mut self) {
+        unsafe {
+            println!("Dropping VulkanSwapchain...");
+            for image_view in self.image_views.drain(..) { // drain to empty the vec
+                self.device.destroy_image_view(image_view, None);
+            }
+            println!("Swapchain image views destroyed (count: {}).", self.images.len());
+
+            // Swapchain must be destroyed before the surface
+            self.swapchain_loader.destroy_swapchain(self.swapchain, None);
+            println!("Swapchain destroyed.");
+
+            // Surface is destroyed after the swapchain
+            // Only destroy surface if this VulkanSwapchain instance created it and is its sole owner.
+            // In the current VulkanSwapchain::new, it does create it.
+            // If create_swapchain_direct is used elsewhere, surface lifetime is managed by caller.
+            self.surface_loader.destroy_surface(self.surface, None);
+            println!("Surface destroyed.");
+            // The device and instance_ref (Arc<AshDevice> and Arc<AshInstance>)
+            // will be dropped automatically by RAII when VulkanSwapchain goes out of scope.
+            // Their respective Drop impls will handle vkDestroyDevice and vkDestroyInstance if this
+            // was the last reference.
+            println!("VulkanSwapchain dropped.");
+        }
+    }
+}
         let surface_format = Self::choose_surface_format(&support_details.formats);
         let present_mode = Self::choose_present_mode(&support_details.present_modes);
         let extent = Self::choose_swap_extent(&support_details.capabilities, window_width, window_height);
@@ -104,9 +500,10 @@ impl VulkanSwapchain {
             .image_color_space(surface_format.color_space)
             .image_extent(extent)
             .image_array_layers(1)
-            .image_usage(vk::ImageUsageFlags::COLOR_ATTACHMENT); // Add other usages if needed (e.g., TRANSFER_DST)
+            // Spec 5.2.4: VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT
+            .image_usage(vk::ImageUsageFlags::COLOR_ATTACHMENT | vk::ImageUsageFlags::TRANSFER_DST);
 
-        let queue_family_indices = [
+        let queue_family_indices_array = [ // Renamed to avoid conflict
             context.graphics_queue_family_index(),
             context.present_queue_family_index(),
         ];
@@ -114,7 +511,7 @@ impl VulkanSwapchain {
         if context.graphics_queue_family_index() != context.present_queue_family_index() {
             create_info = create_info
                 .image_sharing_mode(vk::SharingMode::CONCURRENT)
-                .queue_family_indices(&queue_family_indices);
+                .queue_family_indices(&queue_family_indices_array);
         } else {
             create_info = create_info.image_sharing_mode(vk::SharingMode::EXCLUSIVE);
         }


### PR DESCRIPTION
This commit introduces the foundational components for a Vulkan-based rendering system, implementing the core logic as specified in "Rendering Vulkan.md" and following the project's EPIC/Work Package structure.

Key features and components implemented:

**EPIC-01: Core System & Initialization:**
- Instance creation with validation layers and debug messenger (`instance.rs`).
- Physical device selection tailored for target hardware (AMD Vega 8), including feature and extension checks (`device.rs`).
- Logical device creation with necessary queues (graphics, present, compute, transfer).
- Wayland surface creation via `ash-window` and `raw-window-handle` (`surface.rs`).

**EPIC-02: Memory & Resource Foundation:**
- Memory allocator setup using `gpu-allocator` (`memory.rs`).
- Generic buffer creation function supporting various usage flags and memory locations, considering UMA optimizations (`memory.rs`).
- Generic image creation function and a flexible image view creation function (`memory.rs`, `image.rs`).
- `VulkanImage` struct to manage image resources.

**EPIC-03: First Visible Output (Swapchain & Basic Pipeline):**
- Swapchain creation and management, including image and view retrieval (`swapchain.rs::create_swapchain_direct`).
- Render pass definition for a single color attachment, suitable for clearing and presentation (`render_pass.rs`).
- Framebuffer creation for swapchain image views (`framebuffer.rs`).
- Minimal graphics pipeline setup:
    - Empty pipeline layout (no descriptors/push constants initially).
    - Pipeline state configured for no vertex input, dynamic viewport/scissor, and simple output for screen clearing/basic drawing.
    - Shader loading for minimal vertex/fragment shaders.
- `VulkanRenderer` main struct (`mod.rs`) significantly enhanced:
    - Initialization of all above components.
    - Management of command pools, command buffers (per frame-in-flight).
    - Synchronization primitives (semaphores, fences per frame-in-flight).
    - Implementation of `record_main_command_buffer` and `draw_frame` methods to achieve a clear screen output using a fullscreen triangle.

**EPIC-04: Data Handling & Geometry Rendering:**
- `SimpleVertex` struct defined for position and tex_coord (color initially).
- Vertex and Index buffer creation and data upload in `VulkanRenderer`, using `CpuToGpu` memory for UMA friendliness.
- Graphics pipeline updated to use vertex input descriptions.
- Command buffer recording updated for indexed drawing (`vkCmdDrawIndexed`).
- Uniform Buffer Object (UBO) setup:
    - `UniformBufferObject` struct for MVP matrices.
    - Descriptor set layout, descriptor pool, descriptor sets, and uniform buffers (per frame-in-flight) created in `VulkanRenderer`.
    - Pipeline layout updated to include UBO descriptor set layout.
    - `update_uniform_buffer` method added to `VulkanRenderer`.
    - Shaders (conceptually, files `textured_geometry.vert.spv` and `textured_geometry.frag.spv` now expected) updated for UBOs.
- `glam` crate added for matrix math.

**EPIC-05: Erweiterte Rendering-Features:**
- Texture Management:
    - Mipmap generation logic added to `texture_pipeline.rs`.
    - Sampler creation (`create_texture_sampler`) added and integrated into `GpuTexture` and texture loading.
    - `VulkanRenderer` updated to handle combined image sampler in its main descriptor set layout and binds a default texture.
    - Shaders (conceptually, `textured_geometry.vert.spv` and `textured_geometry.frag.spv`) updated for texture sampling.
- Compute Pipeline:
    - Basic setup for a compute pipeline in `VulkanRenderer`, including a storage image, compute-specific descriptor set layout, pipeline layout, compute pipeline, command buffer, and fence.
    - `dispatch_compute_shader` method added to execute a simple compute shader (placeholder `compute_shader.comp.spv` expected).

**EPIC-06: Performance, Parallelisierung & Stabilität:**
- GPU Timestamp Queries:
    - Added `timestamp_query_pool` to `VulkanRenderer`.
    - Implemented timestamp recording in the main command buffer.
    - Added `get_last_frame_gpu_duration_ms()` method to retrieve results.
- Error handling uses `Result<T, String>` throughout.
- Command pools configured with `RESET_COMMAND_BUFFER_BIT`.

All implemented modules include Rustdoc comments for public items. Unit test definitions and structure have been outlined for EPICs 01, 02, and 03.

Note: Placeholder shader files (minimal, geometry, textured_geometry, compute) are expected to be created and compiled to SPIR-V by the user/build system and placed in the `assets/shaders/` directory.